### PR TITLE
T03 gestao de veiculos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Use localhost when running on the host; use db when running inside Docker Compose
 DATABASE_URL=postgresql://oficina:oficina@localhost:5432/oficina
-SECRET_KEY=change-me-in-production-use-a-long-random-string
+SECRET_KEY=dev-secret-key
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 SMTP_HOST=mailhog

--- a/README.md
+++ b/README.md
@@ -113,6 +113,46 @@ Resposta admin inclui `documents: ["52998224725"]` (lista normalizada, sem másc
 
 Por segurança, a rota pública retorna apenas `{ "id", "name" }` — sem e-mail, telefone ou endereço.
 
+## Gestão de veículos (T03 — RF02)
+
+Veículos vinculados a clientes cadastrados (T02). Regras de domínio:
+
+- Placa validada nos formatos **legado** (`ABC1234`) e **Mercosul** (`ABC1D23`)
+- Placa inválida → HTTP 422 com mensagem `Veículo inválido`
+- Não pode haver dois veículos com a **mesma placa para o mesmo cliente** → HTTP 409
+- UF validada contra siglas brasileiras (2 letras)
+
+### APIs administrativas (JWT)
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/api/v1/admin/vehicles` | Cadastrar veículo |
+| `GET` | `/api/v1/admin/vehicles` | Listar todos os veículos |
+| `GET` | `/api/v1/admin/vehicles/{id}` | Buscar veículo por ID |
+| `PUT` | `/api/v1/admin/vehicles/{id}` | Atualizar veículo |
+| `DELETE` | `/api/v1/admin/vehicles/{id}` | Remover veículo |
+| `GET` | `/api/v1/admin/customers/{id}/vehicles` | Listar veículos do cliente |
+
+Exemplo de criação:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/admin/vehicles \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": 1,
+    "plate": "ABC1D23",
+    "state": "SP",
+    "city": "São Paulo",
+    "color": "Prata",
+    "brand": "VW",
+    "model": "Gol",
+    "year": 2021
+  }'
+```
+
+No painel Angular, selecione um cliente em **Clientes** para listar e cadastrar veículos associados.
+
 ## Painel web Angular (admin completo)
 
 Frontend em **Angular 15** com CRUD master-detail para todas as entidades administrativas.

--- a/alembic/versions/004_unique_service_product_lines.py
+++ b/alembic/versions/004_unique_service_product_lines.py
@@ -1,7 +1,7 @@
 """Ensure one product line per service product.
 
-Revision ID: 004
-Revises: 003
+Revision ID: 004a
+Revises: 004
 Create Date: 2026-06-23
 """
 
@@ -10,8 +10,8 @@ from typing import Sequence, Union
 from alembic import op
 
 
-revision: str = "004"
-down_revision: Union[str, None] = "003"
+revision: str = "004a"
+down_revision: Union[str, None] = "004"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/005_products_require_supplier.py
+++ b/alembic/versions/005_products_require_supplier.py
@@ -12,7 +12,7 @@ from alembic import op
 
 
 revision: str = "005"
-down_revision: Union[str, None] = "004"
+down_revision: Union[str, None] = "004a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/006_vehicle_location_and_color.py
+++ b/alembic/versions/006_vehicle_location_and_color.py
@@ -1,0 +1,44 @@
+"""Add vehicle location/color fields and per-customer plate uniqueness.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("vehicles", sa.Column("state", sa.String(2), nullable=True))
+    op.add_column("vehicles", sa.Column("city", sa.String(100), nullable=True))
+    op.add_column("vehicles", sa.Column("color", sa.String(50), nullable=True))
+
+    op.execute("UPDATE vehicles SET state = 'SP', city = 'Não informado', color = 'Não informado'")
+
+    op.alter_column("vehicles", "state", nullable=False)
+    op.alter_column("vehicles", "city", nullable=False)
+    op.alter_column("vehicles", "color", nullable=False)
+
+    op.drop_index("ix_vehicles_plate", table_name="vehicles")
+    op.create_index("ix_vehicles_plate", "vehicles", ["plate"], unique=False)
+    op.create_unique_constraint(
+        "uq_vehicles_customer_plate", "vehicles", ["customer_id", "plate"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_vehicles_customer_plate", "vehicles", type_="unique")
+    op.drop_index("ix_vehicles_plate", table_name="vehicles")
+    op.create_index("ix_vehicles_plate", "vehicles", ["plate"], unique=True)
+    op.drop_column("vehicles", "color")
+    op.drop_column("vehicles", "city")
+    op.drop_column("vehicles", "state")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "8001:8000"
     environment:
       DATABASE_URL: postgresql://oficina:oficina@db:5432/oficina
-      SECRET_KEY: dev-secret-key-change-in-production
+      SECRET_KEY: dev-secret-key
       SMTP_HOST: mailhog
       SMTP_PORT: 1025
       SMTP_FROM: noreply@oficina.local

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -518,7 +518,7 @@ Obrigatórios para avaliação, mas separados do backlog de implementação dos 
 ### Cadastros e validações
 
 - [ ] **RF01** — Gestão do Cliente
-- [ ] **RF02** — Gestão do Veículo
+- [x] **RF02** — Gestão do Veículo
 - [ ] **RF03** — Gestão de Produtos (Peças e Insumos)
 - [ ] **RF04** — Gestão de Serviços
 - [ ] **RF05** — Validação de CNPJ

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { ServiceOrdersComponent } from './component/service-orders/service-order
 import { ServiceOrderDetailComponent } from './component/service-orders/service-order-detail/service-order-detail.component';
 import { ServiceOrderTrackingComponent } from './component/service-order-tracking/service-order-tracking.component';
 
+import { FormErrorAlertComponent } from './component/shared/form-error-alert.component';
 import { AuthInterceptor } from './service/auth.interceptor';
 import { HttpErrorInterceptor } from './service/http-error.interceptor';
 
@@ -68,6 +69,7 @@ import { HttpErrorInterceptor } from './service/http-error.interceptor';
     ServiceOrdersComponent,
     ServiceOrderDetailComponent,
     ServiceOrderTrackingComponent,
+    FormErrorAlertComponent,
   ],
   imports: [BrowserModule, FormsModule, AppRoutingModule, HttpClientModule],
   providers: [

--- a/frontend/src/app/component/customers/customer-detail/customer-detail.component.css
+++ b/frontend/src/app/component/customers/customer-detail/customer-detail.component.css
@@ -3,3 +3,22 @@
   font-size: 0.85rem;
   color: var(--color-text);
 }
+
+.vehicle-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+}
+
+.vehicle-list .list-header,
+.vehicle-list .list-item {
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr 0.75fr;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+}
+
+.vehicle-list .list-header {
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border, #ddd);
+}

--- a/frontend/src/app/component/customers/customer-detail/customer-detail.component.html
+++ b/frontend/src/app/component/customers/customer-detail/customer-detail.component.html
@@ -115,4 +115,36 @@
       <p *ngIf="!cnpjValidation.valid">CNPJ inválido</p>
     </div>
   </div>
+
+  <div class="action-section">
+    <h3>Veículos do cliente</h3>
+    <ul class="model-list vehicle-list" *ngIf="vehicles.length > 0">
+      <li class="list-header">
+        <span class="col-1">Placa</span>
+        <span class="col-2">Marca / Modelo</span>
+        <span class="col-3">Cor</span>
+        <span class="col-4">Ano</span>
+      </li>
+      <li *ngFor="let vehicle of vehicles" class="list-item">
+        <span class="col-1">{{ vehicle.plate }}</span>
+        <span class="col-2">{{ vehicle.brand }} / {{ vehicle.model }}</span>
+        <span class="col-3">{{ vehicle.color }}</span>
+        <span class="col-4">{{ vehicle.year }}</span>
+      </li>
+    </ul>
+    <p *ngIf="vehicles.length === 0 && !creatingNewVehicle" class="validation-result">
+      Nenhum veículo cadastrado para este cliente.
+    </p>
+    <div class="button-list" *ngIf="!creatingNewVehicle">
+      <button class="btn btn-secondary" type="button" (click)="showVehicleForm()">
+        Adicionar novo
+      </button>
+    </div>
+    <app-new-vehicle
+      *ngIf="creatingNewVehicle"
+      [customerId]="customerId"
+      (vehicleCreated)="onVehicleCreated()"
+      (cancelled)="onVehicleFormCancelled()"
+    ></app-new-vehicle>
+  </div>
 </div>

--- a/frontend/src/app/component/customers/customer-detail/customer-detail.component.ts
+++ b/frontend/src/app/component/customers/customer-detail/customer-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
-import { CnpjValidation, CpfValidation, Customer } from '../../../model/models';
+import { CnpjValidation, CpfValidation, Customer, Vehicle } from '../../../model/models';
 import { CustomerService } from '../../../service/customer.service';
+import { VehicleService } from '../../../service/vehicle.service';
 import { CustomersComponent } from '../customers.component';
 
 @Component({
@@ -12,23 +13,28 @@ export class CustomerDetailComponent implements OnChanges {
   @Input() customerId!: number;
 
   customer: Customer | undefined;
+  vehicles: Vehicle[] = [];
   isCustomerChanged = false;
+  creatingNewVehicle = false;
   newDocument = '';
   cnpjValidation: CnpjValidation | null = null;
   cpfValidation: CpfValidation | null = null;
 
   constructor(
     private customerService: CustomerService,
+    private vehicleService: VehicleService,
     private parent: CustomersComponent
   ) {}
 
   ngOnChanges(): void {
     if (this.customerId) {
       this.isCustomerChanged = false;
+      this.creatingNewVehicle = false;
       this.newDocument = '';
       this.cnpjValidation = null;
       this.cpfValidation = null;
       this.loadCustomer();
+      this.loadVehicles();
     }
   }
 
@@ -36,6 +42,12 @@ export class CustomerDetailComponent implements OnChanges {
     this.customerService.getById(this.customerId).subscribe((data) => {
       this.customer = data;
       this.isCustomerChanged = false;
+    });
+  }
+
+  loadVehicles(): void {
+    this.vehicleService.getByCustomer(this.customerId).subscribe((data) => {
+      this.vehicles = data.sort((a, b) => a.id - b.id);
     });
   }
 
@@ -94,5 +106,18 @@ export class CustomerDetailComponent implements OnChanges {
       this.newDocument = '';
       this.parent.updateCustomerInList(updated);
     });
+  }
+
+  showVehicleForm(): void {
+    this.creatingNewVehicle = true;
+  }
+
+  onVehicleCreated(): void {
+    this.creatingNewVehicle = false;
+    this.loadVehicles();
+  }
+
+  onVehicleFormCancelled(): void {
+    this.creatingNewVehicle = false;
   }
 }

--- a/frontend/src/app/component/login/login.component.ts
+++ b/frontend/src/app/component/login/login.component.ts
@@ -14,8 +14,11 @@ export class LoginComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    if (this.authService.isLoggedIn()) {
+    const token = this.authService.getToken();
+    if (token && this.authService.isLoggedIn()) {
       this.router.navigate(['/menu']);
+    } else if (token) {
+      this.authService.logout();
     }
   }
 

--- a/frontend/src/app/component/shared/form-error-alert.component.css
+++ b/frontend/src/app/component/shared/form-error-alert.component.css
@@ -1,0 +1,25 @@
+.form-error-alert {
+  margin: 1rem 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid #f87171;
+  border-left: 4px solid #ef4444;
+  border-radius: 6px;
+  background: rgba(239, 68, 68, 0.12);
+  color: #fecaca;
+}
+
+.form-error-alert__title {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fca5a5;
+}
+
+.form-error-alert__message {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: #fecaca;
+  white-space: pre-wrap;
+}

--- a/frontend/src/app/component/shared/form-error-alert.component.html
+++ b/frontend/src/app/component/shared/form-error-alert.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="message" class="form-error-alert" role="alert" aria-live="polite">
+  <strong class="form-error-alert__title">{{ title }}</strong>
+  <p class="form-error-alert__message">{{ message }}</p>
+</div>

--- a/frontend/src/app/component/shared/form-error-alert.component.ts
+++ b/frontend/src/app/component/shared/form-error-alert.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-form-error-alert',
+  templateUrl: './form-error-alert.component.html',
+  styleUrls: ['./form-error-alert.component.css'],
+})
+export class FormErrorAlertComponent {
+  @Input() title = 'Verifique os dados informados';
+  @Input() message = '';
+}

--- a/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.html
+++ b/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.html
@@ -1,7 +1,7 @@
 <p class="detail-title-text">Novo veículo</p>
 <form #formRef="ngForm" (ngSubmit)="saveVehicle(formRef.value)">
   <div class="field-list">
-    <div class="field-name">
+    <div class="field-name" *ngIf="!customerId">
       <span>ID do cliente</span>
       <input
         class="text-input small-input"
@@ -18,6 +18,28 @@
         class="text-input medium-input"
         type="text"
         name="plate"
+        ngModel
+        required
+      />
+    </div>
+    <div class="field-name">
+      <span>UF</span>
+      <input
+        class="text-input small-input"
+        type="text"
+        name="state"
+        ngModel
+        required
+        minlength="2"
+        maxlength="2"
+      />
+    </div>
+    <div class="field-name">
+      <span>Cidade</span>
+      <input
+        class="text-input medium-input"
+        type="text"
+        name="city"
         ngModel
         required
       />
@@ -43,6 +65,16 @@
       />
     </div>
     <div class="field-name">
+      <span>Cor</span>
+      <input
+        class="text-input medium-input"
+        type="text"
+        name="color"
+        ngModel
+        required
+      />
+    </div>
+    <div class="field-name">
       <span>Ano</span>
       <input
         class="text-input small-input"
@@ -55,9 +87,18 @@
       />
     </div>
   </div>
+  <p *ngIf="errorMessage" class="validation-result">{{ errorMessage }}</p>
   <div class="button-list">
     <button class="btn btn-primary" type="submit" [disabled]="formRef.invalid">
       Salvar
+    </button>
+    <button
+      *ngIf="customerId"
+      class="btn btn-secondary"
+      type="button"
+      (click)="cancel()"
+    >
+      Cancelar
     </button>
   </div>
 </form>

--- a/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.html
+++ b/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.html
@@ -1,5 +1,6 @@
 <p class="detail-title-text">Novo veículo</p>
-<form #formRef="ngForm" (ngSubmit)="saveVehicle(formRef.value)">
+<app-form-error-alert [title]="errorTitle" [message]="errorMessage"></app-form-error-alert>
+<form #formRef="ngForm" (ngSubmit)="saveVehicle(formRef.value)" (input)="clearError()">
   <div class="field-list">
     <div class="field-name" *ngIf="!customerId">
       <span>ID do cliente</span>
@@ -20,6 +21,7 @@
         name="plate"
         ngModel
         required
+        placeholder="ABC1D23"
       />
     </div>
     <div class="field-name">
@@ -32,6 +34,8 @@
         required
         minlength="2"
         maxlength="2"
+        placeholder="SP"
+        style="text-transform: uppercase"
       />
     </div>
     <div class="field-name">
@@ -87,7 +91,6 @@
       />
     </div>
   </div>
-  <p *ngIf="errorMessage" class="validation-result">{{ errorMessage }}</p>
   <div class="button-list">
     <button class="btn btn-primary" type="submit" [disabled]="formRef.invalid">
       Salvar

--- a/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.ts
+++ b/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { VehicleService } from '../../../service/vehicle.service';
+import { extractApiErrorMessage } from '../../../util/api-error';
+import { validateVehicleForm } from '../../../util/vehicle-form';
 
 @Component({
   selector: 'app-new-vehicle',
@@ -13,8 +15,13 @@ export class NewVehicleComponent {
   @Output() cancelled = new EventEmitter<void>();
 
   errorMessage = '';
+  errorTitle = 'Não foi possível cadastrar o veículo';
 
   constructor(private vehicleService: VehicleService) {}
+
+  clearError(): void {
+    this.errorMessage = '';
+  }
 
   saveVehicle(data: {
     customer_id?: string;
@@ -26,50 +33,58 @@ export class NewVehicleComponent {
     model: string;
     year: string;
   }): void {
-    const resolvedCustomerId = this.customerId ?? Number(data.customer_id);
-    if (!resolvedCustomerId) {
-      this.errorMessage = 'Cliente é obrigatório';
+    const validation = validateVehicleForm(
+      {
+        customer_id: this.customerId ?? data.customer_id,
+        plate: data.plate,
+        state: data.state,
+        city: data.city,
+        color: data.color,
+        brand: data.brand,
+        model: data.model,
+        year: data.year,
+      },
+      { requirePlate: true, requireCustomerId: !this.customerId }
+    );
+
+    if ('error' in validation) {
+      this.errorTitle = 'Dados inválidos no formulário';
+      this.errorMessage = validation.error;
       return;
     }
 
-    const body = {
-      customer_id: resolvedCustomerId,
-      plate: data.plate.trim(),
-      state: data.state.trim(),
-      city: data.city.trim(),
-      color: data.color.trim(),
-      brand: data.brand.trim(),
-      model: data.model.trim(),
-      year: Number(data.year),
-    };
-
+    const { data: body } = validation;
     this.errorMessage = '';
-    this.vehicleService.create(body).subscribe({
-      next: () => {
-        if (this.customerId) {
-          this.vehicleCreated.emit();
-        } else {
-          window.location.reload();
-        }
-      },
-      error: (error: HttpErrorResponse) => {
-        this.errorMessage = this.extractErrorMessage(error);
-      },
-    });
+    this.vehicleService
+      .create({
+        customer_id: this.customerId ?? body.customer_id,
+        plate: body.plate,
+        state: body.state,
+        city: body.city,
+        color: body.color,
+        brand: body.brand,
+        model: body.model,
+        year: body.year,
+      })
+      .subscribe({
+        next: () => {
+          if (this.customerId) {
+            this.vehicleCreated.emit();
+          } else {
+            window.location.reload();
+          }
+        },
+        error: (error: HttpErrorResponse) => {
+          this.errorTitle = 'Não foi possível cadastrar o veículo';
+          this.errorMessage = extractApiErrorMessage(
+            error,
+            'Não foi possível salvar o veículo.'
+          );
+        },
+      });
   }
 
   cancel(): void {
     this.cancelled.emit();
-  }
-
-  private extractErrorMessage(error: HttpErrorResponse): string {
-    const detail = error.error?.detail;
-    if (typeof detail === 'string') {
-      return detail;
-    }
-    if (Array.isArray(detail) && detail.length > 0) {
-      return detail.map((item: { msg?: string }) => item.msg ?? '').join('; ');
-    }
-    return 'Não foi possível salvar o veículo';
   }
 }

--- a/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.ts
+++ b/frontend/src/app/component/vehicles/new-vehicle/new-vehicle.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { VehicleService } from '../../../service/vehicle.service';
 
 @Component({
@@ -7,24 +8,68 @@ import { VehicleService } from '../../../service/vehicle.service';
   styleUrls: ['./new-vehicle.component.css'],
 })
 export class NewVehicleComponent {
+  @Input() customerId?: number;
+  @Output() vehicleCreated = new EventEmitter<void>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  errorMessage = '';
+
   constructor(private vehicleService: VehicleService) {}
 
   saveVehicle(data: {
-    customer_id: string;
+    customer_id?: string;
     plate: string;
+    state: string;
+    city: string;
+    color: string;
     brand: string;
     model: string;
     year: string;
   }): void {
+    const resolvedCustomerId = this.customerId ?? Number(data.customer_id);
+    if (!resolvedCustomerId) {
+      this.errorMessage = 'Cliente é obrigatório';
+      return;
+    }
+
     const body = {
-      customer_id: Number(data.customer_id),
+      customer_id: resolvedCustomerId,
       plate: data.plate.trim(),
+      state: data.state.trim(),
+      city: data.city.trim(),
+      color: data.color.trim(),
       brand: data.brand.trim(),
       model: data.model.trim(),
       year: Number(data.year),
     };
-    this.vehicleService.create(body).subscribe(() => {
-      window.location.reload();
+
+    this.errorMessage = '';
+    this.vehicleService.create(body).subscribe({
+      next: () => {
+        if (this.customerId) {
+          this.vehicleCreated.emit();
+        } else {
+          window.location.reload();
+        }
+      },
+      error: (error: HttpErrorResponse) => {
+        this.errorMessage = this.extractErrorMessage(error);
+      },
     });
+  }
+
+  cancel(): void {
+    this.cancelled.emit();
+  }
+
+  private extractErrorMessage(error: HttpErrorResponse): string {
+    const detail = error.error?.detail;
+    if (typeof detail === 'string') {
+      return detail;
+    }
+    if (Array.isArray(detail) && detail.length > 0) {
+      return detail.map((item: { msg?: string }) => item.msg ?? '').join('; ');
+    }
+    return 'Não foi possível salvar o veículo';
   }
 }

--- a/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.html
+++ b/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.html
@@ -11,6 +11,41 @@
         <label class="readonly">{{ vehicle.customer_id }}</label>
       </div>
       <div class="field-name">
+        <span>UF</span>
+        <input
+          class="text-input small-input"
+          type="text"
+          name="state"
+          [(ngModel)]="vehicle.state"
+          (ngModelChange)="vehicleChanged()"
+          required
+          minlength="2"
+          maxlength="2"
+        />
+      </div>
+      <div class="field-name">
+        <span>Cidade</span>
+        <input
+          class="text-input medium-input"
+          type="text"
+          name="city"
+          [(ngModel)]="vehicle.city"
+          (ngModelChange)="vehicleChanged()"
+          required
+        />
+      </div>
+      <div class="field-name">
+        <span>Cor</span>
+        <input
+          class="text-input medium-input"
+          type="text"
+          name="color"
+          [(ngModel)]="vehicle.color"
+          (ngModelChange)="vehicleChanged()"
+          required
+        />
+      </div>
+      <div class="field-name">
         <span>Marca</span>
         <input
           class="text-input medium-input"

--- a/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.html
+++ b/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.html
@@ -1,5 +1,6 @@
 <div *ngIf="vehicle">
   <p class="detail-title-text">Veículo #{{ vehicle.id }}</p>
+  <app-form-error-alert [title]="errorTitle" [message]="errorMessage"></app-form-error-alert>
   <form #formRef="ngForm">
     <div class="field-list">
       <div class="field-name">

--- a/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.ts
+++ b/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.ts
@@ -1,6 +1,9 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Vehicle } from '../../../model/models';
 import { VehicleService } from '../../../service/vehicle.service';
+import { extractApiErrorMessage } from '../../../util/api-error';
+import { validateVehicleForm } from '../../../util/vehicle-form';
 import { VehiclesComponent } from '../vehicles.component';
 
 @Component({
@@ -13,6 +16,8 @@ export class VehicleDetailComponent implements OnChanges {
 
   vehicle: Vehicle | undefined;
   isVehicleChanged = false;
+  errorMessage = '';
+  errorTitle = 'Não foi possível atualizar o veículo';
 
   constructor(
     private vehicleService: VehicleService,
@@ -22,37 +27,71 @@ export class VehicleDetailComponent implements OnChanges {
   ngOnChanges(): void {
     if (this.vehicleId) {
       this.isVehicleChanged = false;
+      this.clearError();
       this.loadVehicle();
     }
   }
 
   loadVehicle(): void {
-    this.vehicleService.getById(this.vehicleId).subscribe((data) => {
-      this.vehicle = data;
-      this.isVehicleChanged = false;
+    this.vehicleService.getById(this.vehicleId).subscribe({
+      next: (data) => {
+        this.vehicle = data;
+        this.isVehicleChanged = false;
+      },
+      error: (error: HttpErrorResponse) => {
+        this.errorTitle = 'Não foi possível carregar o veículo';
+        this.errorMessage = extractApiErrorMessage(error);
+      },
     });
   }
 
   vehicleChanged(): void {
     this.isVehicleChanged = true;
+    this.clearError();
+  }
+
+  clearError(): void {
+    this.errorMessage = '';
   }
 
   updateVehicle(): void {
     if (!this.vehicle) {
       return;
     }
-    const body = {
-      state: this.vehicle.state,
-      city: this.vehicle.city,
-      color: this.vehicle.color,
-      brand: this.vehicle.brand,
-      model: this.vehicle.model,
-      year: this.vehicle.year,
-    };
-    this.vehicleService.update(this.vehicleId, body).subscribe((updated) => {
-      this.vehicle = updated;
-      this.isVehicleChanged = false;
-      this.parent.updateVehicleInList(updated);
+
+    const validation = validateVehicleForm(
+      {
+        state: this.vehicle.state,
+        city: this.vehicle.city,
+        color: this.vehicle.color,
+        brand: this.vehicle.brand,
+        model: this.vehicle.model,
+        year: this.vehicle.year,
+      },
+      { requirePlate: false }
+    );
+
+    if ('error' in validation) {
+      this.errorTitle = 'Dados inválidos no formulário';
+      this.errorMessage = validation.error;
+      return;
+    }
+
+    const { data: body } = validation;
+    this.errorMessage = '';
+    this.vehicleService.update(this.vehicleId, body).subscribe({
+      next: (updated) => {
+        this.vehicle = updated;
+        this.isVehicleChanged = false;
+        this.parent.updateVehicleInList(updated);
+      },
+      error: (error: HttpErrorResponse) => {
+        this.errorTitle = 'Não foi possível atualizar o veículo';
+        this.errorMessage = extractApiErrorMessage(
+          error,
+          'Não foi possível atualizar o veículo.'
+        );
+      },
     });
   }
 }

--- a/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.ts
+++ b/frontend/src/app/component/vehicles/vehicle-detail/vehicle-detail.component.ts
@@ -42,6 +42,9 @@ export class VehicleDetailComponent implements OnChanges {
       return;
     }
     const body = {
+      state: this.vehicle.state,
+      city: this.vehicle.city,
+      color: this.vehicle.color,
       brand: this.vehicle.brand,
       model: this.vehicle.model,
       year: this.vehicle.year,

--- a/frontend/src/app/component/vehicles/vehicles.component.css
+++ b/frontend/src/app/component/vehicles/vehicles.component.css
@@ -1,3 +1,8 @@
+.model-list-block app-form-error-alert {
+  display: block;
+  padding: 1rem 1rem 0;
+}
+
 .col-1 {
   flex-basis: 12%;
 }

--- a/frontend/src/app/component/vehicles/vehicles.component.html
+++ b/frontend/src/app/component/vehicles/vehicles.component.html
@@ -6,6 +6,11 @@
     ></app-head-navigation>
   </div>
   <div class="model-list-block scrollbar">
+    <app-form-error-alert
+      *ngIf="loadErrorMessage"
+      [title]="loadErrorTitle"
+      [message]="loadErrorMessage"
+    ></app-form-error-alert>
     <ul class="model-list">
       <li class="list-header">
         <span class="col-1">ID</span>

--- a/frontend/src/app/component/vehicles/vehicles.component.ts
+++ b/frontend/src/app/component/vehicles/vehicles.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Vehicle } from '../../model/models';
 import { VehicleService } from '../../service/vehicle.service';
+import { extractApiErrorMessage } from '../../util/api-error';
 
 @Component({
   selector: 'app-vehicles',
@@ -11,12 +13,27 @@ export class VehiclesComponent implements OnInit {
   vehicles: Vehicle[] = [];
   selectedVehicleId: number | undefined;
   creatingNewVehicle = false;
+  loadErrorMessage = '';
+  loadErrorTitle = 'Não foi possível carregar os veículos';
 
   constructor(private vehicleService: VehicleService) {}
 
   ngOnInit(): void {
-    this.vehicleService.getAll().subscribe((data) => {
-      this.vehicles = data.sort((a, b) => a.id - b.id);
+    this.loadVehicles();
+  }
+
+  loadVehicles(): void {
+    this.loadErrorMessage = '';
+    this.vehicleService.getAll().subscribe({
+      next: (data) => {
+        this.vehicles = data.sort((a, b) => a.id - b.id);
+      },
+      error: (error: HttpErrorResponse) => {
+        this.loadErrorMessage = extractApiErrorMessage(
+          error,
+          'Não foi possível carregar a lista de veículos.'
+        );
+      },
     });
   }
 

--- a/frontend/src/app/model/models.ts
+++ b/frontend/src/app/model/models.ts
@@ -50,6 +50,9 @@ export interface Vehicle {
   id: number;
   customer_id: number;
   plate: string;
+  state: string;
+  city: string;
+  color: string;
   brand: string;
   model: string;
   year: number;

--- a/frontend/src/app/service/auth.guard.ts
+++ b/frontend/src/app/service/auth.guard.ts
@@ -10,6 +10,9 @@ export class AuthGuard implements CanActivate {
     if (this.authService.isLoggedIn()) {
       return true;
     }
+    if (this.authService.getToken()) {
+      this.authService.logout();
+    }
     this.router.navigate(['/login']);
     return false;
   }

--- a/frontend/src/app/service/auth.interceptor.ts
+++ b/frontend/src/app/service/auth.interceptor.ts
@@ -12,9 +12,17 @@ import { AuthService } from './auth.service';
 export class AuthInterceptor implements HttpInterceptor {
   constructor(private authService: AuthService) {}
 
+  private isApiRequest(url: string): boolean {
+    return (
+      url.startsWith('api/') ||
+      url.startsWith('/api/') ||
+      url.includes('/api/v1/')
+    );
+  }
+
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     const token = this.authService.getToken();
-    if (token && req.url.startsWith('api/')) {
+    if (token && this.isApiRequest(req.url) && !req.url.includes('/auth/login')) {
       req = req.clone({
         setHeaders: { Authorization: `Bearer ${token}` },
       });

--- a/frontend/src/app/service/auth.service.ts
+++ b/frontend/src/app/service/auth.service.ts
@@ -13,6 +13,7 @@ export class AuthService {
   constructor(private http: HttpClient) {}
 
   login(credentials: LoginRequest): Observable<TokenResponse> {
+    this.logout();
     return this.http.post<TokenResponse>(`${this.authUrl}/login`, credentials).pipe(
       tap((response) => {
         localStorage.setItem(TOKEN_KEY, response.access_token);
@@ -27,7 +28,12 @@ export class AuthService {
   }
 
   getToken(): string | null {
-    return localStorage.getItem(TOKEN_KEY);
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) {
+      return null;
+    }
+    const trimmed = token.trim();
+    return trimmed.length > 0 ? trimmed : null;
   }
 
   getUsername(): string | null {
@@ -35,6 +41,23 @@ export class AuthService {
   }
 
   isLoggedIn(): boolean {
-    return !!this.getToken();
+    const token = this.getToken();
+    return !!token && !this.isTokenExpired(token);
+  }
+
+  isTokenExpired(token: string): boolean {
+    try {
+      const payload = token.split('.')[1];
+      if (!payload) {
+        return true;
+      }
+      const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+      if (typeof decoded.exp !== 'number') {
+        return true;
+      }
+      return decoded.exp * 1000 < Date.now();
+    } catch {
+      return true;
+    }
   }
 }

--- a/frontend/src/app/service/http-error.interceptor.ts
+++ b/frontend/src/app/service/http-error.interceptor.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import {
   HttpErrorResponse,
   HttpEvent,
@@ -9,14 +10,30 @@ import {
 } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { AuthService } from './auth.service';
 
 @Injectable()
 export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
+
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(req).pipe(
       catchError((error: HttpErrorResponse) => {
+        if (error.status === 401 && this.isProtectedApiRequest(req.url)) {
+          this.authService.logout();
+          if (this.router.url !== '/login') {
+            this.router.navigate(['/login']);
+          }
+        }
+
         let message = error.message;
-        if (error.error?.detail) {
+        if (error.status === 401 && this.isProtectedApiRequest(req.url)) {
+          message =
+            'Sessão expirada ou inválida. Faça login novamente (use apenas uma API: local :8000 ou Docker :8001).';
+        } else if (error.error?.detail) {
           message = typeof error.error.detail === 'string'
             ? error.error.detail
             : JSON.stringify(error.error.detail);
@@ -27,6 +44,10 @@ export class HttpErrorInterceptor implements HttpInterceptor {
         return throwError(() => error);
       })
     );
+  }
+
+  private isProtectedApiRequest(url: string): boolean {
+    return url.includes('/api/v1/admin/');
   }
 }
 

--- a/frontend/src/app/service/vehicle.service.ts
+++ b/frontend/src/app/service/vehicle.service.ts
@@ -20,6 +20,12 @@ export class VehicleService {
     return this.http.get<Vehicle>(`${this.url}/${id}`);
   }
 
+  getByCustomer(customerId: number): Observable<Vehicle[]> {
+    return this.http.get<Vehicle[]>(
+      `api/v1/admin/customers/${customerId}/vehicles`
+    );
+  }
+
   create(body: object): Observable<Vehicle> {
     return this.http.post<Vehicle>(this.url, body, this.httpOptions);
   }

--- a/frontend/src/app/service/vehicle.service.ts
+++ b/frontend/src/app/service/vehicle.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Vehicle } from '../model/models';
+import { SKIP_GLOBAL_ERROR_ALERT } from './http-error.interceptor';
 
 @Injectable({ providedIn: 'root' })
 export class VehicleService {
   private url = 'api/v1/admin/vehicles';
-  private httpOptions = {
+  private jsonOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
+    context: new HttpContext().set(SKIP_GLOBAL_ERROR_ALERT, true),
   };
 
   constructor(private http: HttpClient) {}
@@ -27,11 +29,11 @@ export class VehicleService {
   }
 
   create(body: object): Observable<Vehicle> {
-    return this.http.post<Vehicle>(this.url, body, this.httpOptions);
+    return this.http.post<Vehicle>(this.url, body, this.jsonOptions);
   }
 
   update(id: number, body: object): Observable<Vehicle> {
-    return this.http.put<Vehicle>(`${this.url}/${id}`, body, this.httpOptions);
+    return this.http.put<Vehicle>(`${this.url}/${id}`, body, this.jsonOptions);
   }
 
   delete(id: number): Observable<void> {

--- a/frontend/src/app/util/api-error.ts
+++ b/frontend/src/app/util/api-error.ts
@@ -1,0 +1,27 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+export function extractApiErrorMessage(
+  error: HttpErrorResponse,
+  fallback = 'Não foi possível concluir a operação.'
+): string {
+  const detail = error.error?.detail;
+  if (typeof detail === 'string') {
+    return detail.replace(/^Dados inválidos:\s*/i, '').trim();
+  }
+  if (Array.isArray(detail) && detail.length > 0) {
+    return detail
+      .map((item: { msg?: string; loc?: (string | number)[] }) => {
+        const field = item.loc?.length ? String(item.loc[item.loc.length - 1]) : '';
+        const msg = item.msg ?? 'Valor inválido';
+        return field ? `${field}: ${msg}` : msg;
+      })
+      .join('; ');
+  }
+  if (error.status === 0) {
+    return 'Não foi possível conectar à API. Verifique se o servidor está rodando na porta 8000.';
+  }
+  if (error.status === 409) {
+    return typeof detail === 'string' ? detail : 'Registro em conflito com dados existentes.';
+  }
+  return fallback;
+}

--- a/frontend/src/app/util/vehicle-form.ts
+++ b/frontend/src/app/util/vehicle-form.ts
@@ -1,0 +1,100 @@
+export interface VehicleFormInput {
+  plate?: string;
+  state: string;
+  city: string;
+  color: string;
+  brand: string;
+  model: string;
+  year: string | number;
+  customer_id?: string | number;
+}
+
+export interface NormalizedVehicleForm {
+  plate?: string;
+  state: string;
+  city: string;
+  color: string;
+  brand: string;
+  model: string;
+  year: number;
+  customer_id?: number;
+}
+
+export function isValidPlate(plate: string): boolean {
+  return (
+    /^[A-Z]{3}[0-9]{4}$/.test(plate) || /^[A-Z]{3}[0-9][A-Z0-9][0-9]{2}$/.test(plate)
+  );
+}
+
+export function normalizePlate(raw: string): string {
+  return raw.trim().toUpperCase().replace(/[-\s]/g, '');
+}
+
+export function validateVehicleForm(
+  input: VehicleFormInput,
+  options: { requirePlate?: boolean; requireCustomerId?: boolean } = {}
+): { error: string } | { data: NormalizedVehicleForm } {
+  const requirePlate = options.requirePlate ?? true;
+  const requireCustomerId = options.requireCustomerId ?? false;
+
+  let customer_id: number | undefined;
+  if (requireCustomerId || input.customer_id !== undefined) {
+    customer_id = Number(input.customer_id);
+    if (!customer_id || Number.isNaN(customer_id)) {
+      return { error: 'Informe um ID de cliente válido.' };
+    }
+  }
+
+  const plate = input.plate ? normalizePlate(input.plate) : undefined;
+  if (requirePlate) {
+    if (!plate) {
+      return { error: 'A placa é obrigatória.' };
+    }
+    if (!isValidPlate(plate)) {
+      return {
+        error:
+          'Placa inválida. Use formato antigo (ABC1234) ou Mercosul (ABC1D23), sem hífen.',
+      };
+    }
+  }
+
+  const state = input.state.trim().toUpperCase();
+  if (state.length !== 2) {
+    return { error: 'UF inválida. Informe 2 letras (ex.: SP, RJ).' };
+  }
+
+  const city = input.city.trim();
+  const color = input.color.trim();
+  const brand = input.brand.trim();
+  const model = input.model.trim();
+  if (!city) {
+    return { error: 'A cidade é obrigatória.' };
+  }
+  if (!color) {
+    return { error: 'A cor é obrigatória.' };
+  }
+  if (!brand) {
+    return { error: 'A marca é obrigatória.' };
+  }
+  if (!model) {
+    return { error: 'O modelo é obrigatório.' };
+  }
+
+  const year = Number(input.year);
+  if (!Number.isInteger(year) || year < 1900 || year > 2100) {
+    return { error: 'Ano inválido. Informe um valor entre 1900 e 2100.' };
+  }
+
+  return {
+    data: {
+      plate,
+      state,
+      city,
+      color,
+      brand,
+      model,
+      year,
+      customer_id,
+    },
+  };
+}

--- a/src/api/composition/vehicles.py
+++ b/src/api/composition/vehicles.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+
+from src.application.services.vehicle_service import VehicleService
+from src.infrastructure.persistence.customer_repository import SqlAlchemyCustomerLookup
+from src.infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
+from src.infrastructure.persistence.vehicle_repository import SqlAlchemyVehicleRepository
+
+
+def compose_vehicle_service(db: Session) -> VehicleService:
+    return VehicleService(
+        vehicles=SqlAlchemyVehicleRepository(db),
+        customers=SqlAlchemyCustomerLookup(db),
+        uow=SqlAlchemyUnitOfWork(db),
+    )

--- a/src/api/mappers/vehicles.py
+++ b/src/api/mappers/vehicles.py
@@ -1,0 +1,17 @@
+from src.api.schemas import VehicleResponse
+from src.domain.vehicle.entity import Vehicle
+
+
+def vehicle_to_response(vehicle: Vehicle) -> VehicleResponse:
+    return VehicleResponse(
+        id=vehicle.id,
+        customer_id=vehicle.customer_id,
+        plate=str(vehicle.plate),
+        state=vehicle.state,
+        city=vehicle.city,
+        color=vehicle.color,
+        brand=vehicle.brand,
+        model=vehicle.model,
+        year=vehicle.year,
+        created_at=vehicle.created_at,
+    )

--- a/src/api/routers/customers.py
+++ b/src/api/routers/customers.py
@@ -2,8 +2,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from src.api.composition.customers import compose_customer_service
+from src.api.composition.vehicles import compose_vehicle_service
 from src.api.dependencies import domain_error_handler, get_current_user
 from src.api.mappers.customers import customer_to_response
+from src.api.mappers.vehicles import vehicle_to_response
 from src.api.schemas import (
     CnpjValidationResponse,
     CpfValidationResponse,
@@ -11,6 +13,7 @@ from src.api.schemas import (
     CustomerDocumentAdd,
     CustomerResponse,
     CustomerUpdate,
+    VehicleResponse,
 )
 from src.domain.auth.entity import User
 from src.domain.exceptions import DomainError
@@ -91,6 +94,19 @@ def validate_cpf(
             valid=result.valid,
             formatted=result.formatted,
         )
+    except DomainError as e:
+        raise domain_error_handler(e)
+
+
+@router.get("/{customer_id}/vehicles", response_model=list[VehicleResponse])
+def list_customer_vehicles(
+    customer_id: int,
+    db: Session = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    try:
+        vehicles = compose_vehicle_service(db).list_by_customer(customer_id)
+        return [vehicle_to_response(vehicle) for vehicle in vehicles]
     except DomainError as e:
         raise domain_error_handler(e)
 

--- a/src/api/routers/vehicles.py
+++ b/src/api/routers/vehicles.py
@@ -1,36 +1,35 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from src.api.composition.vehicles import compose_vehicle_service
 from src.api.dependencies import domain_error_handler, get_current_user
+from src.api.mappers.vehicles import vehicle_to_response
 from src.api.schemas import VehicleCreate, VehicleResponse, VehicleUpdate
-from src.application.services.vehicle_service import VehicleService
+from src.domain.auth.entity import User
 from src.domain.exceptions import DomainError
-from src.infrastructure.database import UserModel, get_db
-from src.infrastructure.persistence.customer_repository import SqlAlchemyCustomerLookup
-from src.infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
-from src.infrastructure.persistence.vehicle_repository import SqlAlchemyVehicleRepository
+from src.infrastructure.database import get_db
 
 router = APIRouter(prefix="/admin/vehicles", tags=["Vehicles"])
-
-
-def compose_vehicle_service(db: Session) -> VehicleService:
-    return VehicleService(
-        vehicles=SqlAlchemyVehicleRepository(db),
-        customers=SqlAlchemyCustomerLookup(db),
-        uow=SqlAlchemyUnitOfWork(db),
-    )
 
 
 @router.post("", response_model=VehicleResponse, status_code=201)
 def create_vehicle(
     data: VehicleCreate,
     db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
+    _: User = Depends(get_current_user),
 ):
     try:
-        return compose_vehicle_service(db).create(
-            data.customer_id, data.plate, data.brand, data.model, data.year
+        vehicle = compose_vehicle_service(db).create(
+            data.customer_id,
+            data.plate,
+            data.state,
+            data.city,
+            data.color,
+            data.brand,
+            data.model,
+            data.year,
         )
+        return vehicle_to_response(vehicle)
     except DomainError as e:
         raise domain_error_handler(e)
 
@@ -38,28 +37,21 @@ def create_vehicle(
 @router.get("", response_model=list[VehicleResponse])
 def list_vehicles(
     db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
+    _: User = Depends(get_current_user),
 ):
-    return compose_vehicle_service(db).list_all()
-
-
-@router.get("/customer/{customer_id}", response_model=list[VehicleResponse])
-def list_customer_vehicles(
-    customer_id: int,
-    db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
-):
-    return compose_vehicle_service(db).list_by_customer(customer_id)
+    vehicles = compose_vehicle_service(db).list_all()
+    return [vehicle_to_response(vehicle) for vehicle in vehicles]
 
 
 @router.get("/{vehicle_id}", response_model=VehicleResponse)
 def get_vehicle(
     vehicle_id: int,
     db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
+    _: User = Depends(get_current_user),
 ):
     try:
-        return compose_vehicle_service(db).get_by_id(vehicle_id)
+        vehicle = compose_vehicle_service(db).get_by_id(vehicle_id)
+        return vehicle_to_response(vehicle)
     except DomainError as e:
         raise domain_error_handler(e)
 
@@ -69,10 +61,19 @@ def update_vehicle(
     vehicle_id: int,
     data: VehicleUpdate,
     db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
+    _: User = Depends(get_current_user),
 ):
     try:
-        return compose_vehicle_service(db).update(vehicle_id, data.brand, data.model, data.year)
+        vehicle = compose_vehicle_service(db).update(
+            vehicle_id,
+            data.state,
+            data.city,
+            data.color,
+            data.brand,
+            data.model,
+            data.year,
+        )
+        return vehicle_to_response(vehicle)
     except DomainError as e:
         raise domain_error_handler(e)
 
@@ -81,7 +82,7 @@ def update_vehicle(
 def delete_vehicle(
     vehicle_id: int,
     db: Session = Depends(get_db),
-    _: UserModel = Depends(get_current_user),
+    _: User = Depends(get_current_user),
 ):
     try:
         compose_vehicle_service(db).delete(vehicle_id)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -78,12 +78,18 @@ class CpfValidationResponse(BaseModel):
 class VehicleCreate(BaseModel):
     customer_id: int
     plate: str
+    state: str = Field(min_length=2, max_length=2)
+    city: str = Field(min_length=1)
+    color: str = Field(min_length=1)
     brand: str
     model: str
     year: int = Field(ge=1900, le=2100)
 
 
 class VehicleUpdate(BaseModel):
+    state: str | None = Field(default=None, min_length=2, max_length=2)
+    city: str | None = Field(default=None, min_length=1)
+    color: str | None = Field(default=None, min_length=1)
     brand: str | None = None
     model: str | None = None
     year: int | None = Field(default=None, ge=1900, le=2100)
@@ -93,6 +99,9 @@ class VehicleResponse(BaseModel):
     id: int
     customer_id: int
     plate: str
+    state: str
+    city: str
+    color: str
     brand: str
     model: str
     year: int

--- a/src/application/services/vehicle_service.py
+++ b/src/application/services/vehicle_service.py
@@ -17,7 +17,15 @@ class VehicleService:
         self.uow = uow
 
     def create(
-        self, customer_id: int, plate: str, brand: str, model: str, year: int
+        self,
+        customer_id: int,
+        plate: str,
+        state: str,
+        city: str,
+        color: str,
+        brand: str,
+        model: str,
+        year: int,
     ) -> Vehicle:
         if not self.customers.exists(customer_id):
             raise NotFoundError("Cliente não encontrado")
@@ -25,12 +33,15 @@ class VehicleService:
         vehicle = Vehicle.create(
             customer_id=customer_id,
             plate=plate,
+            state=state,
+            city=city,
+            color=color,
             brand=brand,
             model=model,
             year=year,
         )
-        if self.vehicles.exists_by_plate(vehicle.plate):
-            raise ConflictError("Veículo com esta placa já existe")
+        if self.vehicles.exists_by_customer_and_plate(customer_id, vehicle.plate):
+            raise ConflictError("Veículo com esta placa já existe para o cliente")
 
         created = self.vehicles.add(vehicle)
         self.uow.commit()
@@ -46,17 +57,22 @@ class VehicleService:
         return self.vehicles.list_all(skip, limit)
 
     def list_by_customer(self, customer_id: int) -> list[Vehicle]:
+        if not self.customers.exists(customer_id):
+            raise NotFoundError("Cliente não encontrado")
         return self.vehicles.list_by_customer(customer_id)
 
     def update(
         self,
         vehicle_id: int,
+        state: str | None,
+        city: str | None,
+        color: str | None,
         brand: str | None,
         model: str | None,
         year: int | None,
     ) -> Vehicle:
         vehicle = self.get_by_id(vehicle_id)
-        vehicle.update_details(brand, model, year)
+        vehicle.update_details(state, city, color, brand, model, year)
         updated = self.vehicles.save(vehicle)
         self.uow.commit()
         return updated

--- a/src/domain/value_objects/validators.py
+++ b/src/domain/value_objects/validators.py
@@ -29,4 +29,45 @@ class PlateValidator:
         normalized = plate.upper().replace("-", "").replace(" ", "")
         if cls.LEGACY_PATTERN.match(normalized) or cls.MERCOSUL_PATTERN.match(normalized):
             return normalized
-        raise ValidationError("Placa inválida (formato antigo ou Mercosul)")
+        raise ValidationError("Veículo inválido")
+
+
+class StateValidator:
+    VALID_STATES = frozenset(
+        {
+            "AC",
+            "AL",
+            "AP",
+            "AM",
+            "BA",
+            "CE",
+            "DF",
+            "ES",
+            "GO",
+            "MA",
+            "MT",
+            "MS",
+            "MG",
+            "PA",
+            "PB",
+            "PR",
+            "PE",
+            "PI",
+            "RJ",
+            "RN",
+            "RS",
+            "RO",
+            "RR",
+            "SC",
+            "SP",
+            "SE",
+            "TO",
+        }
+    )
+
+    @classmethod
+    def validate(cls, state: str) -> str:
+        normalized = state.strip().upper()
+        if normalized not in cls.VALID_STATES:
+            raise ValidationError("UF inválida")
+        return normalized

--- a/src/domain/vehicle/entity.py
+++ b/src/domain/vehicle/entity.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from src.domain.exceptions import ValidationError
+from src.domain.value_objects.validators import StateValidator
 from src.domain.vehicle.value_objects import Plate
 
 
@@ -10,6 +11,9 @@ class Vehicle:
     id: int | None
     customer_id: int
     plate: Plate
+    state: str
+    city: str
+    color: str
     brand: str
     model: str
     year: int
@@ -20,6 +24,9 @@ class Vehicle:
         cls,
         customer_id: int,
         plate: str,
+        state: str,
+        city: str,
+        color: str,
         brand: str,
         model: str,
         year: int,
@@ -28,6 +35,9 @@ class Vehicle:
             id=None,
             customer_id=customer_id,
             plate=Plate.create(plate),
+            state=StateValidator.validate(state),
+            city=cls._required_text(city, "Cidade do veículo é obrigatória"),
+            color=cls._required_text(color, "Cor do veículo é obrigatória"),
             brand=cls._required_text(brand, "Marca do veículo é obrigatória"),
             model=cls._required_text(model, "Modelo do veículo é obrigatório"),
             year=cls._valid_year(year),
@@ -35,10 +45,19 @@ class Vehicle:
 
     def update_details(
         self,
+        state: str | None,
+        city: str | None,
+        color: str | None,
         brand: str | None,
         model: str | None,
         year: int | None,
     ) -> None:
+        if state is not None:
+            self.state = StateValidator.validate(state)
+        if city is not None:
+            self.city = self._required_text(city, "Cidade do veículo é obrigatória")
+        if color is not None:
+            self.color = self._required_text(color, "Cor do veículo é obrigatória")
         if brand is not None:
             self.brand = self._required_text(brand, "Marca do veículo é obrigatória")
         if model is not None:

--- a/src/domain/vehicle/repository.py
+++ b/src/domain/vehicle/repository.py
@@ -17,7 +17,7 @@ class VehicleRepository(Protocol):
     def list_by_customer(self, customer_id: int) -> list[Vehicle]:
         ...
 
-    def exists_by_plate(self, plate: Plate) -> bool:
+    def exists_by_customer_and_plate(self, customer_id: int, plate: Plate) -> bool:
         ...
 
     def save(self, vehicle: Vehicle) -> Vehicle:

--- a/src/infrastructure/database.py
+++ b/src/infrastructure/database.py
@@ -82,10 +82,16 @@ class CustomerModel(Base):
 
 class VehicleModel(Base):
     __tablename__ = "vehicles"
+    __table_args__ = (
+        UniqueConstraint("customer_id", "plate", name="uq_vehicles_customer_plate"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"))
-    plate: Mapped[str] = mapped_column(String(10), unique=True, index=True)
+    plate: Mapped[str] = mapped_column(String(10), index=True)
+    state: Mapped[str] = mapped_column(String(2))
+    city: Mapped[str] = mapped_column(String(100))
+    color: Mapped[str] = mapped_column(String(50))
     brand: Mapped[str] = mapped_column(String(100))
     model: Mapped[str] = mapped_column(String(100))
     year: Mapped[int] = mapped_column(Integer)

--- a/src/infrastructure/persistence/vehicle_repository.py
+++ b/src/infrastructure/persistence/vehicle_repository.py
@@ -14,6 +14,9 @@ class SqlAlchemyVehicleRepository:
         model = VehicleModel(
             customer_id=vehicle.customer_id,
             plate=str(vehicle.plate),
+            state=vehicle.state,
+            city=vehicle.city,
+            color=vehicle.color,
             brand=vehicle.brand,
             model=vehicle.model,
             year=vehicle.year,
@@ -41,10 +44,13 @@ class SqlAlchemyVehicleRepository:
         )
         return [self._to_domain(model) for model in models]
 
-    def exists_by_plate(self, plate: Plate) -> bool:
+    def exists_by_customer_and_plate(self, customer_id: int, plate: Plate) -> bool:
         return (
             self.db.query(VehicleModel)
-            .filter(VehicleModel.plate == str(plate))
+            .filter(
+                VehicleModel.customer_id == customer_id,
+                VehicleModel.plate == str(plate),
+            )
             .first()
             is not None
         )
@@ -57,6 +63,9 @@ class SqlAlchemyVehicleRepository:
         if not model:
             raise NotFoundError("Veículo não encontrado")
 
+        model.state = vehicle.state
+        model.city = vehicle.city
+        model.color = vehicle.color
         model.brand = vehicle.brand
         model.model = vehicle.model
         model.year = vehicle.year
@@ -81,6 +90,9 @@ class SqlAlchemyVehicleRepository:
             id=model.id,
             customer_id=model.customer_id,
             plate=Plate.create(model.plate),
+            state=model.state,
+            city=model.city,
+            color=model.color,
             brand=model.brand,
             model=model.model,
             year=model.year,

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -33,6 +33,21 @@ def _supplier_payload(**overrides):
     return payload
 
 
+def _vehicle_payload(customer_id: int, **overrides):
+    payload = {
+        "customer_id": customer_id,
+        "plate": "ABC1D23",
+        "state": "SP",
+        "city": "São Paulo",
+        "color": "Prata",
+        "brand": "VW",
+        "model": "Gol",
+        "year": 2021,
+    }
+    payload.update(overrides)
+    return payload
+
+
 def _create_supplier(client, auth_headers, **overrides):
     return client.post(
         "/api/v1/admin/suppliers",
@@ -140,18 +155,87 @@ def test_vehicle_crud(client, auth_headers):
         json=_pf_customer_payload(name="Pedro", email="pedro@test.com", phone=None),
     ).json()
 
-    vehicle = client.post(
+    create = client.post(
         "/api/v1/admin/vehicles",
         headers=auth_headers,
-        json={
-            "customer_id": customer["id"],
-            "plate": "ABC1D23",
-            "brand": "VW",
-            "model": "Gol",
-            "year": 2021,
-        },
+        json=_vehicle_payload(customer["id"]),
     )
-    assert vehicle.status_code == 201
+    assert create.status_code == 201
+    vehicle = create.json()
+    assert vehicle["state"] == "SP"
+    assert vehicle["city"] == "São Paulo"
+    assert vehicle["color"] == "Prata"
+
+    listed = client.get(
+        f"/api/v1/admin/customers/{customer['id']}/vehicles",
+        headers=auth_headers,
+    )
+    assert listed.status_code == 200
+    assert len(listed.json()) == 1
+    assert listed.json()[0]["plate"] == "ABC1D23"
+
+    updated = client.put(
+        f"/api/v1/admin/vehicles/{vehicle['id']}",
+        headers=auth_headers,
+        json={"color": "Preto"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["color"] == "Preto"
+
+    deleted = client.delete(
+        f"/api/v1/admin/vehicles/{vehicle['id']}",
+        headers=auth_headers,
+    )
+    assert deleted.status_code == 204
+
+
+def test_vehicle_rejects_invalid_plate(client, auth_headers):
+    customer = client.post(
+        "/api/v1/admin/customers",
+        headers=auth_headers,
+        json=_pf_customer_payload(name="Pedro", email="pedro2@test.com", phone=None),
+    ).json()
+
+    response = client.post(
+        "/api/v1/admin/vehicles",
+        headers=auth_headers,
+        json=_vehicle_payload(customer["id"], plate="INVALID"),
+    )
+    assert response.status_code == 422
+    assert "Veículo inválido" in response.json()["detail"]
+
+
+def test_vehicle_rejects_duplicate_plate_for_same_customer(client, auth_headers):
+    customer = client.post(
+        "/api/v1/admin/customers",
+        headers=auth_headers,
+        json=_pf_customer_payload(name="Pedro", email="pedro3@test.com", phone=None),
+    ).json()
+
+    first = client.post(
+        "/api/v1/admin/vehicles",
+        headers=auth_headers,
+        json=_vehicle_payload(customer["id"]),
+    )
+    assert first.status_code == 201
+
+    duplicate = client.post(
+        "/api/v1/admin/vehicles",
+        headers=auth_headers,
+        json=_vehicle_payload(customer["id"], brand="Fiat", model="Uno"),
+    )
+    assert duplicate.status_code == 409
+
+
+def test_customer_vehicles_requires_auth(client, auth_headers):
+    customer = client.post(
+        "/api/v1/admin/customers",
+        headers=auth_headers,
+        json=_pf_customer_payload(name="Pedro", email="pedro4@test.com", phone=None),
+    ).json()
+
+    response = client.get(f"/api/v1/admin/customers/{customer['id']}/vehicles")
+    assert response.status_code == 401
 
 
 def test_service_catalog_crud_and_product_lines(client, auth_headers):
@@ -372,13 +456,7 @@ def test_full_flow(client, auth_headers):
     vehicle = client.post(
         "/api/v1/admin/vehicles",
         headers=auth_headers,
-        json={
-            "customer_id": customer["id"],
-            "plate": "XYZ9A87",
-            "brand": "Toyota",
-            "model": "Corolla",
-            "year": 2022,
-        },
+        json=_vehicle_payload(customer["id"], plate="XYZ9A87", brand="Toyota", model="Corolla", year=2022),
     ).json()
 
     service = client.post(

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,7 +1,7 @@
 import pytest
 
 from src.domain.exceptions import ValidationError
-from src.domain.value_objects.validators import DocumentValidator, PlateValidator
+from src.domain.value_objects.validators import DocumentValidator, PlateValidator, StateValidator
 
 
 class TestDocumentValidator:
@@ -24,5 +24,14 @@ class TestPlateValidator:
         assert PlateValidator.validate("ABC1D23") == "ABC1D23"
 
     def test_invalid_plate(self):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="Veículo inválido"):
             PlateValidator.validate("INVALID")
+
+
+class TestStateValidator:
+    def test_valid_state(self):
+        assert StateValidator.validate("sp") == "SP"
+
+    def test_invalid_state(self):
+        with pytest.raises(ValidationError, match="UF inválida"):
+            StateValidator.validate("XX")

--- a/tests/unit/vehicle/test_vehicle_domain.py
+++ b/tests/unit/vehicle/test_vehicle_domain.py
@@ -5,6 +5,21 @@ from src.domain.vehicle.entity import Vehicle
 from src.domain.vehicle.value_objects import Plate
 
 
+def _vehicle_kwargs(**overrides):
+    base = {
+        "customer_id": 1,
+        "plate": "abc-1234",
+        "state": "sp",
+        "city": "São Paulo",
+        "color": "Preto",
+        "brand": " Fiat ",
+        "model": " Uno ",
+        "year": 2020,
+    }
+    base.update(overrides)
+    return base
+
+
 def test_plate_normalizes_legacy_format():
     assert Plate.create("abc-1234") == "ABC1234"
 
@@ -14,20 +29,17 @@ def test_plate_normalizes_mercosul_format():
 
 
 def test_plate_rejects_invalid_format():
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Veículo inválido"):
         Plate.create("INVALID")
 
 
 def test_vehicle_create_validates_and_normalizes_fields():
-    vehicle = Vehicle.create(
-        customer_id=1,
-        plate="abc-1234",
-        brand=" Fiat ",
-        model=" Uno ",
-        year=2020,
-    )
+    vehicle = Vehicle.create(**_vehicle_kwargs())
 
     assert vehicle.plate == "ABC1234"
+    assert vehicle.state == "SP"
+    assert vehicle.city == "São Paulo"
+    assert vehicle.color == "Preto"
     assert vehicle.brand == "Fiat"
     assert vehicle.model == "Uno"
     assert vehicle.year == 2020
@@ -35,26 +47,29 @@ def test_vehicle_create_validates_and_normalizes_fields():
 
 def test_vehicle_rejects_invalid_year():
     with pytest.raises(ValidationError):
-        Vehicle.create(
-            customer_id=1,
-            plate="ABC1234",
-            brand="Fiat",
-            model="Uno",
-            year=1899,
-        )
+        Vehicle.create(**_vehicle_kwargs(year=1899))
+
+
+def test_vehicle_rejects_invalid_state():
+    with pytest.raises(ValidationError, match="UF inválida"):
+        Vehicle.create(**_vehicle_kwargs(state="XX"))
 
 
 def test_vehicle_updates_details_through_domain_behavior():
-    vehicle = Vehicle.create(
-        customer_id=1,
-        plate="ABC1234",
-        brand="Fiat",
-        model="Uno",
-        year=2020,
+    vehicle = Vehicle.create(**_vehicle_kwargs())
+
+    vehicle.update_details(
+        state="rj",
+        city="Rio de Janeiro",
+        color="Branco",
+        brand="VW",
+        model=None,
+        year=2022,
     )
 
-    vehicle.update_details(brand="VW", model=None, year=2022)
-
+    assert vehicle.state == "RJ"
+    assert vehicle.city == "Rio de Janeiro"
+    assert vehicle.color == "Branco"
     assert vehicle.brand == "VW"
     assert vehicle.model == "Uno"
     assert vehicle.year == 2022

--- a/tests/unit/vehicle/test_vehicle_service.py
+++ b/tests/unit/vehicle/test_vehicle_service.py
@@ -32,8 +32,11 @@ class InMemoryVehicleRepository:
             if vehicle.customer_id == customer_id
         ]
 
-    def exists_by_plate(self, plate: Plate) -> bool:
-        return any(vehicle.plate == plate for vehicle in self.vehicles.values())
+    def exists_by_customer_and_plate(self, customer_id: int, plate: Plate) -> bool:
+        return any(
+            vehicle.customer_id == customer_id and vehicle.plate == plate
+            for vehicle in self.vehicles.values()
+        )
 
     def save(self, vehicle: Vehicle) -> Vehicle:
         assert vehicle.id is not None
@@ -65,15 +68,32 @@ class FakeUnitOfWork:
         self.rollbacks += 1
 
 
+def _vehicle_kwargs(**overrides):
+    base = {
+        "plate": "abc-1234",
+        "state": "sp",
+        "city": "São Paulo",
+        "color": "Preto",
+        "brand": "Fiat",
+        "model": "Uno",
+        "year": 2020,
+    }
+    base.update(overrides)
+    return base
+
+
 def test_vehicle_service_creates_vehicle_without_sqlalchemy():
     vehicles = InMemoryVehicleRepository()
     uow = FakeUnitOfWork()
     service = VehicleService(vehicles, InMemoryCustomerLookup({1}), uow)
 
-    vehicle = service.create(1, "abc-1234", "Fiat", "Uno", 2020)
+    vehicle = service.create(1, **_vehicle_kwargs())
 
     assert vehicle.id == 1
     assert vehicle.plate == "ABC1234"
+    assert vehicle.state == "SP"
+    assert vehicle.city == "São Paulo"
+    assert vehicle.color == "Preto"
     assert uow.commits == 1
 
 
@@ -85,13 +105,35 @@ def test_vehicle_service_rejects_unknown_customer():
     )
 
     with pytest.raises(NotFoundError):
-        service.create(1, "ABC1234", "Fiat", "Uno", 2020)
+        service.create(1, **_vehicle_kwargs())
 
 
-def test_vehicle_service_rejects_duplicate_plate():
+def test_vehicle_service_rejects_duplicate_plate_for_same_customer():
     vehicles = InMemoryVehicleRepository()
     service = VehicleService(vehicles, InMemoryCustomerLookup({1}), FakeUnitOfWork())
-    service.create(1, "ABC1234", "Fiat", "Uno", 2020)
+    service.create(1, **_vehicle_kwargs())
 
-    with pytest.raises(ConflictError):
-        service.create(1, "abc-1234", "VW", "Gol", 2021)
+    with pytest.raises(ConflictError, match="já existe para o cliente"):
+        service.create(1, **_vehicle_kwargs(brand="VW", model="Gol", year=2021))
+
+
+def test_vehicle_service_allows_same_plate_for_different_customers():
+    vehicles = InMemoryVehicleRepository()
+    service = VehicleService(vehicles, InMemoryCustomerLookup({1, 2}), FakeUnitOfWork())
+    service.create(1, **_vehicle_kwargs())
+
+    vehicle = service.create(2, **_vehicle_kwargs())
+
+    assert vehicle.customer_id == 2
+    assert vehicle.plate == "ABC1234"
+
+
+def test_vehicle_service_list_by_customer_requires_existing_customer():
+    service = VehicleService(
+        InMemoryVehicleRepository(),
+        InMemoryCustomerLookup(set()),
+        FakeUnitOfWork(),
+    )
+
+    with pytest.raises(NotFoundError, match="Cliente não encontrado"):
+        service.list_by_customer(1)


### PR DESCRIPTION
## Resumo da branch `T03-gestao-de-veiculos`

**Depende de:** T02 (clientes + autenticação admin)  
**Requisito funcional:** RF02 — Gestão do Veículo  
**Commits:** 2 (`0ce5429` + `194f7d6`)

---

### Objetivo

Implementar o CRUD de veículos vinculados a clientes, com validação de placa brasileira (legado e Mercosul), incluindo backend, banco de dados, testes e interface Angular.

---

### Backend (API)

**Novos campos do veículo:** placa, UF (`state`), cidade, cor, marca, modelo e ano.

**Endpoints:**

| Método | Rota |
|--------|------|
| `POST/GET/PUT/DELETE` | `/api/v1/admin/vehicles` |
| `GET` | `/api/v1/admin/customers/{id}/vehicles` |

**Regras de negócio:**
- Placa inválida → HTTP 422 com `"Veículo inválido"`
- UF validada contra siglas brasileiras
- Unicidade de placa **por cliente** (não global)
- Cliente inexistente → 404
- Placa duplicada para o mesmo cliente → 409

**Arquitetura:** camadas domain → application → infrastructure → API, com `VehicleService`, mapper, composition root e migration Alembic `006`.

---

### Banco de dados

Migration `006_vehicle_location_and_color.py`:
- Colunas `state`, `city`, `color`
- Constraint única `(customer_id, plate)` no lugar da unicidade global da placa

Correção da cadeia Alembic: `003 → 004 → 004a → 005 → 006` (resolvido conflito de revision `004` duplicada).

---

### Frontend (Angular)

**Página Veículos** (`/vehicles`): listagem, detalhe, criação e edição com os novos campos.

**Fluxo por cliente** (em **Clientes** → detalhe):
- Lista “Veículos do cliente”
- Botão “Adicionar novo” com formulário embutido

**Melhorias de UX e autenticação (2º commit):**
- Componente `app-form-error-alert` com mensagens claras
- Validação no formulário antes do envio (placa, UF, ano, campos obrigatórios)
- Tratamento de erros da API sem `alert()` genérico
- `SECRET_KEY` alinhada entre Docker e ambiente local (`dev-secret-key`)
- Guard/interceptor reforçados: token expirado, 401 redireciona para login

---

### Testes

- Testes unitários: domínio, serviço, `StateValidator`, `PlateValidator`
- Testes de integração: CRUD, placa inválida, placa duplicada, rota aninhada por cliente, autenticação

---

### Documentação

- Seção **Gestão de veículos (T03 — RF02)** no `README.md`
- RF02 marcado como concluído em `docs/tasks.md`

---

### Como executar (dev local)

```bash
docker compose up db -d
poetry run alembic upgrade head
poetry run uvicorn src.main:app --reload --host 127.0.0.1 --port 8000
cd frontend && npm start
```

Login: `admin` / `admin123` → http://localhost:4200

---

### Estatísticas

**45 arquivos alterados** · **+1.038 / −136 linhas** em relação à `main`