### PR TITLE
Feature/t11 faturamento encerramento pagamento

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ SMTP_FROM=noreply@oficina.local
 APP_BASE_URL=http://localhost:8000
 FRONTEND_PUBLIC_URL=http://localhost:4200
 INVERTEXTO_API_TOKEN=
+# Skip Invertexto API and validate CPF locally only (useful for local/dev testing)
+SKIP_CPF_EXTERNAL_VALIDATION=true

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ Resposta admin inclui `documents: ["52998224725"]` (lista normalizada, sem másc
 
 Por segurança, a rota pública retorna apenas `{ "id", "name" }` — sem e-mail, telefone ou endereço.
 
+## Faturamento e encerramento (T11 — RF38–RF40)
+
+Após finalizar a OS (`PATCH /admin/service-orders/{id}/finish`), o atendimento pode emitir fatura, registrar pagamento e encerrar a OS como entregue.
+
+### APIs administrativas (JWT)
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| `POST` | `/api/v1/admin/service-orders/{id}/invoice` | Gerar fatura para OS finalizada |
+| `GET` | `/api/v1/admin/service-orders/{id}/invoice` | Consultar fatura da OS |
+| `PATCH` | `/api/v1/admin/invoices/{id}/pay` | Registrar pagamento integral |
+| `PATCH` | `/api/v1/admin/service-orders/{id}/deliver` | Entregar OS (fatura deve estar paga) |
+
+O pagamento integral altera automaticamente o status da OS para `Entregue`.
+
 ## Painel web Angular (admin completo)
 
 Frontend em **Angular 15** com CRUD master-detail para todas as entidades administrativas.

--- a/alembic/versions/007_compatibility_placeholder.py
+++ b/alembic/versions/007_compatibility_placeholder.py
@@ -1,0 +1,22 @@
+"""Compatibility placeholder for databases already stamped as revision 007.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-06-30
+"""
+
+from typing import Sequence, Union
+
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -551,7 +551,7 @@ Obrigatórios para avaliação, mas separados do backlog de implementação dos 
 - [ ] **RF33** — Finalização de atendimento
 - [ ] **RF36** — Monitoramento de OS com produto retirado
 - [ ] **RF37** — Atualização ao final do atendimento
-- [ ] **RF40** — Encerramento após pagamento
+- [x] **RF40** — Encerramento após pagamento
 
 ### Estoque, reserva e compras
 
@@ -567,8 +567,8 @@ Obrigatórios para avaliação, mas separados do backlog de implementação dos 
 
 ### Faturamento
 
-- [ ] **RF38** — Geração de fatura
-- [ ] **RF39** — Registro de pagamento
+- [x] **RF38** — Geração de fatura
+- [x] **RF39** — Registro de pagamento
 
 ### Requisitos técnicos e entregáveis da Fase 1
 

--- a/frontend/src/app/component/budgets/budget-detail/budget-detail.component.css
+++ b/frontend/src/app/component/budgets/budget-detail/budget-detail.component.css
@@ -18,6 +18,20 @@
   color: #c44;
 }
 
+.action-message {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: var(--color-surface);
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.error-message {
+  margin-top: 0.75rem;
+  color: #c62828;
+  font-size: 0.85rem;
+}
+
 .product-lines-table {
   width: 100%;
   max-width: 100%;

--- a/frontend/src/app/component/budgets/budget-detail/budget-detail.component.html
+++ b/frontend/src/app/component/budgets/budget-detail/budget-detail.component.html
@@ -248,7 +248,20 @@
             <button class="btn btn-primary" type="button" (click)="sendEmail()">
                 Enviar e-mail
             </button>
+
+            <button
+                *ngIf="canApprove()"
+                class="btn btn-primary"
+                type="button"
+                (click)="approve()"
+                [disabled]="isApproving"
+            >
+                {{ isApproving ? 'Aprovando...' : 'Aprovar orçamento' }}
+            </button>
         </div>
+
+        <p *ngIf="actionMessage" class="action-message">{{ actionMessage }}</p>
+        <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
     </div>
 
     <div *ngIf="availabilityItems.length" class="action-section">

--- a/frontend/src/app/component/budgets/budget-detail/budget-detail.component.ts
+++ b/frontend/src/app/component/budgets/budget-detail/budget-detail.component.ts
@@ -1,9 +1,11 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   AvailabilityItem,
   Budget,
   BudgetProductLine,
   BudgetServiceLine,
+  BudgetStatus,
   CatalogService,
   Product,
 } from '../../../model/models';
@@ -30,6 +32,10 @@ export class BudgetDetailComponent implements OnChanges {
   productId = 0;
   productQuantity = 1;
   availabilityItems: AvailabilityItem[] = [];
+  actionMessage = '';
+  errorMessage = '';
+  isApproving = false;
+  readonly budgetStatus = BudgetStatus;
 
   constructor(
     private budgetService: BudgetService,
@@ -41,6 +47,8 @@ export class BudgetDetailComponent implements OnChanges {
   ngOnChanges(): void {
     if (this.budgetId) {
       this.availabilityItems = [];
+      this.actionMessage = '';
+      this.errorMessage = '';
       this.loadBudget();
       this.loadProducts();
       this.loadCatalogServices();
@@ -137,6 +145,41 @@ export class BudgetDetailComponent implements OnChanges {
     this.budgetService.sendEmail(this.budgetId).subscribe((updated) => {
       this.budget = updated;
       this.parent.updateBudgetInList(updated);
+    });
+  }
+
+  canApprove(): boolean {
+    if (!this.budget) {
+      return false;
+    }
+    const hasLines = this.serviceLines.length > 0 || this.productLines.length > 0;
+    return (
+      hasLines &&
+      [BudgetStatus.DRAFT, BudgetStatus.SENT].includes(this.budget.status)
+    );
+  }
+
+  approve(): void {
+    if (!this.canApprove()) {
+      return;
+    }
+    this.isApproving = true;
+    this.errorMessage = '';
+    this.budgetService.approve(this.budgetId).subscribe({
+      next: (response) => {
+        this.actionMessage = response.message;
+        this.reloadBudget();
+      },
+      complete: () => {
+        this.isApproving = false;
+      },
+      error: (error) => {
+        this.isApproving = false;
+        const httpError = error as HttpErrorResponse;
+        this.errorMessage =
+          (typeof httpError?.error?.detail === 'string' && httpError.error.detail) ||
+          'Não foi possível aprovar o orçamento.';
+      },
     });
   }
 

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.css
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.css
@@ -6,3 +6,9 @@
   font-size: 0.85rem;
   color: var(--color-text);
 }
+
+.error-message {
+  margin-top: 0.75rem;
+  color: #c62828;
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
@@ -57,17 +57,6 @@
         />
       </div>
       <div class="field-name">
-        <span>Status</span>
-        <select
-          class="select-input medium-input"
-          name="status"
-          [(ngModel)]="selectedStatus"
-          [ngModelOptions]="{ standalone: true }"
-        >
-          <option *ngFor="let s of statusValues" [ngValue]="s">{{ s }}</option>
-        </select>
-      </div>
-      <div class="field-name">
         <span>Prioridade</span>
         <select
           class="select-input medium-input"
@@ -82,6 +71,38 @@
     <div class="button-list">
       <button class="btn btn-secondary" type="button" (click)="saveChanges()" [disabled]="isSaving">
         {{ isSaving ? 'Salvando...' : 'Salvar alterações' }}
+      </button>
+    </div>
+  </div>
+
+  <div class="action-section">
+    <h3>Override administrativo de status</h3>
+    <div class="field-list">
+      <div class="field-name">
+        <span>Novo status</span>
+        <select
+          class="select-input medium-input"
+          name="status"
+          [(ngModel)]="selectedStatus"
+          [ngModelOptions]="{ standalone: true }"
+        >
+          <option *ngFor="let s of statusValues" [ngValue]="s">{{ s }}</option>
+        </select>
+      </div>
+      <div class="field-name">
+        <span>Motivo</span>
+        <input
+          class="text-input medium-input"
+          type="text"
+          name="statusOverrideReason"
+          [(ngModel)]="statusOverrideReason"
+          [ngModelOptions]="{ standalone: true }"
+        />
+      </div>
+    </div>
+    <div class="button-list">
+      <button class="btn btn-secondary" type="button" (click)="overrideStatus()" [disabled]="isOverridingStatus">
+        {{ isOverridingStatus ? 'Alterando...' : 'Alterar status' }}
       </button>
     </div>
   </div>

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
@@ -103,6 +103,36 @@
       >
         {{ isFinishing ? 'Finalizando...' : 'Finalizar serviço' }}
       </button>
+    </div>
+    <span *ngIf="shouldShowStart() && !canStart()" class="action-message">
+      Mecânico obrigatório para iniciar. Salve o mecânico antes de iniciar.
+    </span>
+  </div>
+
+  <div *ngIf="shouldShowBillingSection()" class="action-section">
+    <h3>Faturamento</h3>
+    <p *ngIf="!invoice" class="action-message">
+      Nenhuma fatura emitida para esta OS.
+    </p>
+    <div *ngIf="invoice" class="field-list">
+      <div class="field-name">
+        <span>Fatura</span>
+        <label class="readonly">#{{ invoice.id }}</label>
+      </div>
+      <div class="field-name">
+        <span>Status</span>
+        <label class="readonly">{{ invoice.status }}</label>
+      </div>
+      <div class="field-name">
+        <span>Valor</span>
+        <label class="readonly">R$ {{ invoice.amount | number: '1.2-2' }}</label>
+      </div>
+      <div class="field-name" *ngIf="invoice.paid_at">
+        <span>Pago em</span>
+        <label class="readonly">{{ invoice.paid_at | date: 'dd/MM/yyyy HH:mm' }}</label>
+      </div>
+    </div>
+    <div class="button-list">
       <button
         *ngIf="canCreateInvoice()"
         class="btn btn-secondary"
@@ -122,15 +152,10 @@
         {{ isPayingInvoice ? 'Registrando...' : 'Registrar pagamento' }}
       </button>
     </div>
-    <span *ngIf="shouldShowStart() && !canStart()" class="action-message">
-      Mecânico obrigatório para iniciar. Salve o mecânico antes de iniciar.
-    </span>
+    <p *ngIf="errorMessage" class="error-message">{{ errorMessage }}</p>
   </div>
 
   <div *ngIf="actionMessage" class="action-message">
     {{ actionMessage }}
-  </div>
-  <div *ngIf="invoice" class="action-message">
-    Fatura: #{{ invoice.id }} — {{ invoice.status }} — R$ {{ invoice.amount | number: '1.2-2' }}
   </div>
 </div>

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.html
@@ -18,10 +18,6 @@
       <label class="readonly">{{ serviceOrder.status }}</label>
     </div>
     <div class="field-name">
-      <span>Prioridade</span>
-      <label class="readonly">{{ serviceOrder.priority }}</label>
-    </div>
-    <div class="field-name">
       <span>Mecânico</span>
       <label class="readonly">{{ serviceOrder.mechanic_name || '—' }}</label>
     </div>
@@ -59,6 +55,17 @@
           [(ngModel)]="mechanicName"
           [ngModelOptions]="{ standalone: true }"
         />
+      </div>
+      <div class="field-name">
+        <span>Status</span>
+        <select
+          class="select-input medium-input"
+          name="status"
+          [(ngModel)]="selectedStatus"
+          [ngModelOptions]="{ standalone: true }"
+        >
+          <option *ngFor="let s of statusValues" [ngValue]="s">{{ s }}</option>
+        </select>
       </div>
       <div class="field-name">
         <span>Prioridade</span>

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
@@ -22,7 +22,9 @@ export class ServiceOrderDetailComponent implements OnChanges {
   serviceOrder: ServiceOrder | undefined;
   mechanicName = '';
   selectedPriority: Priority = Priority.NORMAL;
+  selectedStatus: ServiceOrderStatus = ServiceOrderStatus.AGUARDANDO_APROVACAO;
   priorityValues = Object.values(Priority);
+  statusValues = Object.values(ServiceOrderStatus);
   invoice: Invoice | null = null;
   actionMessage = '';
   errorMessage = '';
@@ -54,6 +56,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
       this.serviceOrder = data;
       this.mechanicName = data.mechanic_name || '';
       this.selectedPriority = data.priority;
+      this.selectedStatus = data.status;
       this.loadInvoice();
     });
   }
@@ -75,16 +78,22 @@ export class ServiceOrderDetailComponent implements OnChanges {
 
   saveChanges(): void {
     const name = this.mechanicName.trim();
-    const payload: ServiceOrderUpdate = { priority: this.selectedPriority };
+    const payload: ServiceOrderUpdate = {
+      priority: this.selectedPriority,
+      status: this.selectedStatus,
+    };
     if (name) {
       payload.mechanic_name = name;
     }
     this.isSaving = true;
+    this.errorMessage = '';
     this.serviceOrderService.update(this.serviceOrderId, payload).subscribe({
       next: (updated) => {
         this.serviceOrder = updated;
+        this.selectedStatus = updated.status;
         this.parent.updateServiceOrderInList(updated);
         this.actionMessage = 'Ordem de serviço atualizada.';
+        this.loadInvoice();
       },
       complete: () => {
         this.isSaving = false;

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
   Invoice,
   InvoiceStatus,
@@ -24,6 +25,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
   priorityValues = Object.values(Priority);
   invoice: Invoice | null = null;
   actionMessage = '';
+  errorMessage = '';
   isSaving = false;
   isSendingEmail = false;
   isStarting = false;
@@ -41,6 +43,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
   ngOnChanges(): void {
     if (this.serviceOrderId) {
       this.actionMessage = '';
+      this.errorMessage = '';
       this.invoice = null;
       this.loadServiceOrder();
     }
@@ -56,6 +59,10 @@ export class ServiceOrderDetailComponent implements OnChanges {
   }
 
   loadInvoice(): void {
+    if (!this.shouldShowBillingSection()) {
+      this.invoice = null;
+      return;
+    }
     this.serviceOrderService.getInvoice(this.serviceOrderId).subscribe({
       next: (invoice) => {
         this.invoice = invoice;
@@ -172,6 +179,23 @@ export class ServiceOrderDetailComponent implements OnChanges {
     });
   }
 
+  shouldShowBillingSection(): boolean {
+    return Boolean(
+      this.serviceOrder &&
+      [
+        ServiceOrderStatus.FINALIZADA,
+        ServiceOrderStatus.ENTREGUE,
+      ].includes(this.serviceOrder.status)
+    );
+  }
+
+  private setErrorMessage(error: unknown, fallback: string): void {
+    const httpError = error as HttpErrorResponse;
+    this.errorMessage =
+      (typeof httpError?.error?.detail === 'string' && httpError.error.detail) ||
+      fallback;
+  }
+
   canCreateInvoice(): boolean {
     return this.serviceOrder?.status === ServiceOrderStatus.FINALIZADA && !this.invoice;
   }
@@ -188,6 +212,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
       return;
     }
     this.isCreatingInvoice = true;
+    this.errorMessage = '';
     this.serviceOrderService.createInvoice(this.serviceOrderId).subscribe({
       next: (invoice) => {
         this.invoice = invoice;
@@ -196,8 +221,9 @@ export class ServiceOrderDetailComponent implements OnChanges {
       complete: () => {
         this.isCreatingInvoice = false;
       },
-      error: () => {
+      error: (error) => {
         this.isCreatingInvoice = false;
+        this.setErrorMessage(error, 'Não foi possível gerar a fatura.');
       },
     });
   }
@@ -207,6 +233,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
       return;
     }
     this.isPayingInvoice = true;
+    this.errorMessage = '';
     this.serviceOrderService.payInvoice(this.invoice.id).subscribe({
       next: (invoice) => {
         this.invoice = invoice;
@@ -216,8 +243,9 @@ export class ServiceOrderDetailComponent implements OnChanges {
       complete: () => {
         this.isPayingInvoice = false;
       },
-      error: () => {
+      error: (error) => {
         this.isPayingInvoice = false;
+        this.setErrorMessage(error, 'Não foi possível registrar o pagamento.');
       },
     });
   }

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
@@ -34,6 +34,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
   isFinishing = false;
   isCreatingInvoice = false;
   isPayingInvoice = false;
+  private invoiceKnownAbsent = false;
   readonly serviceOrderStatus = ServiceOrderStatus;
   readonly invoiceStatus = InvoiceStatus;
 
@@ -47,6 +48,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
       this.actionMessage = '';
       this.errorMessage = '';
       this.invoice = null;
+      this.invoiceKnownAbsent = false;
       this.loadServiceOrder();
     }
   }
@@ -66,12 +68,19 @@ export class ServiceOrderDetailComponent implements OnChanges {
       this.invoice = null;
       return;
     }
+    if (this.invoiceKnownAbsent && !this.invoice) {
+      return;
+    }
     this.serviceOrderService.getInvoice(this.serviceOrderId).subscribe({
       next: (invoice) => {
         this.invoice = invoice;
+        this.invoiceKnownAbsent = false;
       },
-      error: () => {
+      error: (error: HttpErrorResponse) => {
         this.invoice = null;
+        if (error.status === 404) {
+          this.invoiceKnownAbsent = true;
+        }
       },
     });
   }
@@ -93,7 +102,10 @@ export class ServiceOrderDetailComponent implements OnChanges {
         this.selectedStatus = updated.status;
         this.parent.updateServiceOrderInList(updated);
         this.actionMessage = 'Ordem de serviço atualizada.';
-        this.loadInvoice();
+        if (!this.shouldShowBillingSection()) {
+          this.invoice = null;
+          this.invoiceKnownAbsent = false;
+        }
       },
       complete: () => {
         this.isSaving = false;
@@ -225,6 +237,7 @@ export class ServiceOrderDetailComponent implements OnChanges {
     this.serviceOrderService.createInvoice(this.serviceOrderId).subscribe({
       next: (invoice) => {
         this.invoice = invoice;
+        this.invoiceKnownAbsent = false;
         this.actionMessage = `Fatura #${invoice.id} criada — R$ ${invoice.amount.toFixed(2)}`;
       },
       complete: () => {

--- a/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
+++ b/frontend/src/app/component/service-orders/service-order-detail/service-order-detail.component.ts
@@ -23,12 +23,14 @@ export class ServiceOrderDetailComponent implements OnChanges {
   mechanicName = '';
   selectedPriority: Priority = Priority.NORMAL;
   selectedStatus: ServiceOrderStatus = ServiceOrderStatus.AGUARDANDO_APROVACAO;
+  statusOverrideReason = '';
   priorityValues = Object.values(Priority);
   statusValues = Object.values(ServiceOrderStatus);
   invoice: Invoice | null = null;
   actionMessage = '';
   errorMessage = '';
   isSaving = false;
+  isOverridingStatus = false;
   isSendingEmail = false;
   isStarting = false;
   isFinishing = false;
@@ -89,7 +91,6 @@ export class ServiceOrderDetailComponent implements OnChanges {
     const name = this.mechanicName.trim();
     const payload: ServiceOrderUpdate = {
       priority: this.selectedPriority,
-      status: this.selectedStatus,
     };
     if (name) {
       payload.mechanic_name = name;
@@ -102,10 +103,6 @@ export class ServiceOrderDetailComponent implements OnChanges {
         this.selectedStatus = updated.status;
         this.parent.updateServiceOrderInList(updated);
         this.actionMessage = 'Ordem de serviço atualizada.';
-        if (!this.shouldShowBillingSection()) {
-          this.invoice = null;
-          this.invoiceKnownAbsent = false;
-        }
       },
       complete: () => {
         this.isSaving = false;
@@ -114,6 +111,44 @@ export class ServiceOrderDetailComponent implements OnChanges {
         this.isSaving = false;
       },
     });
+  }
+
+  overrideStatus(): void {
+    const reason = this.statusOverrideReason.trim();
+    if (!reason) {
+      this.errorMessage = 'Motivo obrigatório para alterar status.';
+      return;
+    }
+    this.isOverridingStatus = true;
+    this.errorMessage = '';
+    this.serviceOrderService
+      .overrideStatus(this.serviceOrderId, {
+        status: this.selectedStatus,
+        reason,
+      })
+      .subscribe({
+        next: (updated) => {
+          this.serviceOrder = updated;
+          this.selectedStatus = updated.status;
+          this.statusOverrideReason = '';
+          this.parent.updateServiceOrderInList(updated);
+          this.actionMessage = 'Status da OS alterado por override administrativo.';
+          if (!this.shouldShowBillingSection()) {
+            this.invoice = null;
+            this.invoiceKnownAbsent = false;
+          } else {
+            this.invoiceKnownAbsent = false;
+            this.loadInvoice();
+          }
+        },
+        complete: () => {
+          this.isOverridingStatus = false;
+        },
+        error: (error) => {
+          this.isOverridingStatus = false;
+          this.setErrorMessage(error, 'Não foi possível alterar o status.');
+        },
+      });
   }
 
   sendEmail(): void {

--- a/frontend/src/app/model/models.ts
+++ b/frontend/src/app/model/models.ts
@@ -145,7 +145,11 @@ export interface ServiceOrderPublic {
 export interface ServiceOrderUpdate {
   mechanic_name?: string;
   priority?: Priority;
-  status?: ServiceOrderStatus;
+}
+
+export interface ServiceOrderStatusOverride {
+  status: ServiceOrderStatus;
+  reason: string;
 }
 
 export interface CnpjValidation {

--- a/frontend/src/app/model/models.ts
+++ b/frontend/src/app/model/models.ts
@@ -145,6 +145,7 @@ export interface ServiceOrderPublic {
 export interface ServiceOrderUpdate {
   mechanic_name?: string;
   priority?: Priority;
+  status?: ServiceOrderStatus;
 }
 
 export interface CnpjValidation {

--- a/frontend/src/app/service/budget.service.ts
+++ b/frontend/src/app/service/budget.service.ts
@@ -6,6 +6,7 @@ import {
   Budget,
   BudgetProductLine,
   BudgetServiceLine,
+  MessageResponse,
 } from '../model/models';
 
 @Injectable({ providedIn: 'root' })
@@ -119,6 +120,14 @@ export class BudgetService {
   sendEmail(budgetId: number): Observable<Budget> {
     return this.http.post<Budget>(
       `${this.url}/${budgetId}/send-email`,
+      {},
+      this.httpOptions
+    );
+  }
+
+  approve(budgetId: number): Observable<MessageResponse> {
+    return this.http.patch<MessageResponse>(
+      `${this.url}/${budgetId}/approve`,
       {},
       this.httpOptions
     );

--- a/frontend/src/app/service/service-order.service.ts
+++ b/frontend/src/app/service/service-order.service.ts
@@ -8,6 +8,7 @@ import {
   Priority,
   ServiceOrder,
   ServiceOrderPublic,
+  ServiceOrderStatusOverride,
   ServiceOrderUpdate,
 } from '../model/models';
 import { SKIP_GLOBAL_ERROR_ALERT } from './http-error.interceptor';
@@ -46,6 +47,14 @@ export class ServiceOrderService {
     return this.http.patch<ServiceOrder>(
       `${this.url}/${id}/priority`,
       { priority },
+      this.httpOptions
+    );
+  }
+
+  overrideStatus(id: number, payload: ServiceOrderStatusOverride): Observable<ServiceOrder> {
+    return this.http.patch<ServiceOrder>(
+      `${this.url}/${id}/status-override`,
+      payload,
       this.httpOptions
     );
   }

--- a/src/api/composition/customers.py
+++ b/src/api/composition/customers.py
@@ -10,9 +10,7 @@ from src.infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
 
 
 def compose_customer_service(db: Session) -> CustomerService:
-    use_local_cpf = (
-        settings.skip_cpf_external_validation or not settings.invertexto_api_token.strip()
-    )
+    use_local_cpf = settings.skip_cpf_external_validation
     cpf_validator = (
         LocalCpfValidator()
         if use_local_cpf

--- a/src/api/composition/customers.py
+++ b/src/api/composition/customers.py
@@ -4,14 +4,23 @@ from src.application.services.customer_service import CustomerService
 from src.config import settings
 from src.infrastructure.external.brasil_api_cnpj import HttpBrasilApiCnpjValidator
 from src.infrastructure.external.invertexto_cpf import HttpInvertextoCpfValidator
+from src.infrastructure.external.local_cpf import LocalCpfValidator
 from src.infrastructure.persistence.customer_repository import SqlAlchemyCustomerRepository
 from src.infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
 
 
 def compose_customer_service(db: Session) -> CustomerService:
+    use_local_cpf = (
+        settings.skip_cpf_external_validation or not settings.invertexto_api_token.strip()
+    )
+    cpf_validator = (
+        LocalCpfValidator()
+        if use_local_cpf
+        else HttpInvertextoCpfValidator(token=settings.invertexto_api_token)
+    )
     return CustomerService(
         customers=SqlAlchemyCustomerRepository(db),
         uow=SqlAlchemyUnitOfWork(db),
         cnpj_validator=HttpBrasilApiCnpjValidator(),
-        cpf_validator=HttpInvertextoCpfValidator(token=settings.invertexto_api_token),
+        cpf_validator=cpf_validator,
     )

--- a/src/api/routers/budgets.py
+++ b/src/api/routers/budgets.py
@@ -215,6 +215,19 @@ async def send_budget_email(
         raise domain_error_handler(e)
 
 
+@admin_router.patch("/{budget_id}/approve", response_model=MessageResponse)
+def approve_budget_admin(
+    budget_id: int,
+    db: Session = Depends(get_db),
+    _: UserModel = Depends(get_current_user),
+):
+    try:
+        service_order = compose_budget_approval_service(db).approve_budget_by_id(budget_id)
+        return MessageResponse(message=f"Orçamento aprovado. OS #{service_order.id} criada.")
+    except DomainError as e:
+        raise domain_error_handler(e)
+
+
 @public_router.get("/{token}/approve", response_model=MessageResponse)
 def approve_budget(token: str, db: Session = Depends(get_db)):
     try:

--- a/src/api/routers/service_orders.py
+++ b/src/api/routers/service_orders.py
@@ -11,6 +11,7 @@ from src.api.schemas import (
     AssignMechanicRequest,
     AverageExecutionTimeResponse,
     MessageResponse,
+    OverrideStatusRequest,
     ServiceOrderPublicResponse,
     ServiceOrderResponse,
     ServiceOrderUpdate,
@@ -73,7 +74,23 @@ def update_service_order(
             service_order_id=service_order_id,
             mechanic_name=data.mechanic_name,
             priority=data.priority,
-            status=data.status,
+        )
+    except DomainError as e:
+        raise domain_error_handler(e)
+
+
+@admin_router.patch("/{service_order_id}/status-override", response_model=ServiceOrderResponse)
+def override_status(
+    service_order_id: int,
+    data: OverrideStatusRequest,
+    db: Session = Depends(get_db),
+    _: UserModel = Depends(get_current_user),
+):
+    try:
+        return compose_service_order_service(db).override_status(
+            service_order_id,
+            data.status,
+            data.reason,
         )
     except DomainError as e:
         raise domain_error_handler(e)

--- a/src/api/routers/service_orders.py
+++ b/src/api/routers/service_orders.py
@@ -73,6 +73,7 @@ def update_service_order(
             service_order_id=service_order_id,
             mechanic_name=data.mechanic_name,
             priority=data.priority,
+            status=data.status,
         )
     except DomainError as e:
         raise domain_error_handler(e)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -288,11 +288,16 @@ class ServiceOrderPublicResponse(BaseModel):
 class ServiceOrderUpdate(BaseModel):
     mechanic_name: str | None = Field(default=None, min_length=1)
     priority: Priority | None = None
+    status: ServiceOrderStatus | None = None
 
     @model_validator(mode="after")
     def require_change(self):
-        if self.mechanic_name is None and self.priority is None:
-            raise ValueError("Informe mechanic_name ou priority")
+        if (
+            self.mechanic_name is None
+            and self.priority is None
+            and self.status is None
+        ):
+            raise ValueError("Informe mechanic_name, priority ou status")
         return self
 
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -288,16 +288,11 @@ class ServiceOrderPublicResponse(BaseModel):
 class ServiceOrderUpdate(BaseModel):
     mechanic_name: str | None = Field(default=None, min_length=1)
     priority: Priority | None = None
-    status: ServiceOrderStatus | None = None
 
     @model_validator(mode="after")
     def require_change(self):
-        if (
-            self.mechanic_name is None
-            and self.priority is None
-            and self.status is None
-        ):
-            raise ValueError("Informe mechanic_name, priority ou status")
+        if self.mechanic_name is None and self.priority is None:
+            raise ValueError("Informe mechanic_name ou priority")
         return self
 
 
@@ -307,6 +302,11 @@ class AssignMechanicRequest(BaseModel):
 
 class SetPriorityRequest(BaseModel):
     priority: Priority
+
+
+class OverrideStatusRequest(BaseModel):
+    status: ServiceOrderStatus
+    reason: str = Field(min_length=1)
 
 
 class ReservationCreate(BaseModel):

--- a/src/application/services/budget_approval_service.py
+++ b/src/application/services/budget_approval_service.py
@@ -98,17 +98,21 @@ class BudgetApprovalService:
         budget = self.budgets.get_by_approval_token(token)
         if not budget:
             raise NotFoundError("Orçamento não encontrado")
+        self._validate_can_approve(budget)
         return self._approve_and_create_service_order(budget)
 
     def approve_budget_by_id(self, budget_id: int) -> CreatedServiceOrder:
         budget = self._get_by_id(budget_id)
+        self._validate_can_approve(budget)
+        return self._approve_and_create_service_order(budget)
+
+    def _validate_can_approve(self, budget: Budget) -> None:
         if budget.status == BudgetStatus.REJECTED:
             raise ValidationError("Orçamento recusado não pode ser aprovado")
         if not budget.service_lines and not budget.product_lines:
             raise ValidationError(
                 "Orçamento deve ter linhas de serviço ou produto para ser aprovado"
             )
-        return self._approve_and_create_service_order(budget)
 
     def _approve_and_create_service_order(self, budget: Budget) -> CreatedServiceOrder:
         budget.approve()

--- a/src/application/services/budget_approval_service.py
+++ b/src/application/services/budget_approval_service.py
@@ -10,7 +10,8 @@ from src.application.ports.budget_approval import (
 from src.application.ports.unit_of_work import UnitOfWork
 from src.domain.budget.entity import Budget
 from src.domain.budget.repository import BudgetRepository
-from src.domain.exceptions import NotFoundError
+from src.domain.enums import BudgetStatus
+from src.domain.exceptions import NotFoundError, ValidationError
 
 
 class BudgetApprovalService:
@@ -97,7 +98,19 @@ class BudgetApprovalService:
         budget = self.budgets.get_by_approval_token(token)
         if not budget:
             raise NotFoundError("Orçamento não encontrado")
+        return self._approve_and_create_service_order(budget)
 
+    def approve_budget_by_id(self, budget_id: int) -> CreatedServiceOrder:
+        budget = self._get_by_id(budget_id)
+        if budget.status == BudgetStatus.REJECTED:
+            raise ValidationError("Orçamento recusado não pode ser aprovado")
+        if not budget.service_lines and not budget.product_lines:
+            raise ValidationError(
+                "Orçamento deve ter linhas de serviço ou produto para ser aprovado"
+            )
+        return self._approve_and_create_service_order(budget)
+
+    def _approve_and_create_service_order(self, budget: Budget) -> CreatedServiceOrder:
         budget.approve()
         updated_budget = self.budgets.save(budget)
         service_order = self.service_orders.create_from_budget(updated_budget)

--- a/src/application/services/invoice_service.py
+++ b/src/application/services/invoice_service.py
@@ -1,6 +1,7 @@
 from src.application.ports.billing import BillingClock
 from src.application.ports.unit_of_work import UnitOfWork
 from src.domain.billing.entity import Invoice
+from src.domain.billing.rules import calculate_invoice_amount, validate_priced_lines
 from src.domain.billing.repository import InvoiceRepository
 from src.domain.enums import InvoiceStatus, ServiceOrderStatus
 from src.domain.exceptions import NotFoundError, ValidationError
@@ -30,9 +31,9 @@ class InvoiceService:
         if self.invoices.get_by_service_order_id(service_order_id):
             raise ValidationError("Fatura já existe para esta OS")
 
-        invoice = self.invoices.add(
-            Invoice.create(service_order_id, service_order.total_price)
-        )
+        validate_priced_lines(service_order)
+        amount = calculate_invoice_amount(service_order)
+        invoice = self.invoices.add(Invoice.create(service_order_id, amount))
         self.uow.commit()
         return invoice
 

--- a/src/application/services/invoice_service.py
+++ b/src/application/services/invoice_service.py
@@ -1,7 +1,11 @@
 from src.application.ports.billing import BillingClock
 from src.application.ports.unit_of_work import UnitOfWork
 from src.domain.billing.entity import Invoice
-from src.domain.billing.rules import calculate_invoice_amount, validate_priced_lines
+from src.domain.billing.rules import (
+    calculate_invoice_amount,
+    validate_invoice_total_matches_lines,
+    validate_priced_lines,
+)
 from src.domain.billing.repository import InvoiceRepository
 from src.domain.enums import InvoiceStatus, ServiceOrderStatus
 from src.domain.exceptions import NotFoundError, ValidationError
@@ -32,6 +36,7 @@ class InvoiceService:
             raise ValidationError("Fatura já existe para esta OS")
 
         validate_priced_lines(service_order)
+        validate_invoice_total_matches_lines(service_order)
         amount = calculate_invoice_amount(service_order)
         invoice = self.invoices.add(Invoice.create(service_order_id, amount))
         self.uow.commit()

--- a/src/application/services/service_order_service.py
+++ b/src/application/services/service_order_service.py
@@ -47,15 +47,24 @@ class ServiceOrderService:
         service_order_id: int,
         mechanic_name: str | None = None,
         priority: Priority | None = None,
-        status: ServiceOrderStatus | None = None,
     ) -> ServiceOrder:
         service_order = self.get_by_id(service_order_id)
         if priority is not None:
             service_order.set_priority(priority)
         if mechanic_name is not None:
             service_order.assign_mechanic(mechanic_name)
-        if status is not None:
-            service_order.set_status(status)
+        updated = self.service_orders.save(service_order)
+        self.uow.commit()
+        return updated
+
+    def override_status(
+        self,
+        service_order_id: int,
+        status: ServiceOrderStatus,
+        reason: str,
+    ) -> ServiceOrder:
+        service_order = self.get_by_id(service_order_id)
+        service_order.override_status(status, reason)
         updated = self.service_orders.save(service_order)
         self.uow.commit()
         return updated

--- a/src/application/services/service_order_service.py
+++ b/src/application/services/service_order_service.py
@@ -47,12 +47,15 @@ class ServiceOrderService:
         service_order_id: int,
         mechanic_name: str | None = None,
         priority: Priority | None = None,
+        status: ServiceOrderStatus | None = None,
     ) -> ServiceOrder:
         service_order = self.get_by_id(service_order_id)
-        if mechanic_name is not None:
-            service_order.assign_mechanic(mechanic_name)
         if priority is not None:
             service_order.set_priority(priority)
+        if mechanic_name is not None:
+            service_order.assign_mechanic(mechanic_name)
+        if status is not None:
+            service_order.set_status(status)
         updated = self.service_orders.save(service_order)
         self.uow.commit()
         return updated

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     app_base_url: str = "http://localhost:8000"
     frontend_public_url: str = "http://localhost:4200"
     invertexto_api_token: str = ""
+    skip_cpf_external_validation: bool = False
 
 
 settings = Settings()

--- a/src/domain/billing/entity.py
+++ b/src/domain/billing/entity.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from src.domain.enums import InvoiceStatus
+from src.domain.exceptions import ValidationError
 
 
 @dataclass
@@ -22,5 +23,7 @@ class Invoice:
         )
 
     def pay(self, paid_at: datetime) -> None:
+        if self.status == InvoiceStatus.PAID:
+            raise ValidationError("Fatura já está paga")
         self.status = InvoiceStatus.PAID
         self.paid_at = paid_at

--- a/src/domain/billing/rules.py
+++ b/src/domain/billing/rules.py
@@ -1,0 +1,27 @@
+from src.domain.exceptions import ValidationError
+from src.domain.service_order.entity import ServiceOrder
+
+
+def calculate_invoice_amount(service_order: ServiceOrder) -> float:
+    service_total = sum(
+        line.unit_price * line.quantity for line in service_order.service_lines
+    )
+    product_total = sum(
+        line.unit_price * line.quantity for line in service_order.product_lines
+    )
+    return service_total + product_total
+
+
+def validate_priced_lines(service_order: ServiceOrder) -> None:
+    for line in service_order.service_lines:
+        if line.unit_price is None or line.unit_price <= 0:
+            raise ValidationError(
+                "Itens sem precificação válida: revise os valores de venda "
+                "dos serviços e produtos antes da emissão da fatura"
+            )
+    for line in service_order.product_lines:
+        if line.unit_price is None or line.unit_price <= 0:
+            raise ValidationError(
+                "Itens sem precificação válida: revise os valores de venda "
+                "dos serviços e produtos antes da emissão da fatura"
+            )

--- a/src/domain/billing/rules.py
+++ b/src/domain/billing/rules.py
@@ -12,6 +12,14 @@ def calculate_invoice_amount(service_order: ServiceOrder) -> float:
     return service_total + product_total
 
 
+def validate_invoice_total_matches_lines(service_order: ServiceOrder) -> None:
+    line_total = calculate_invoice_amount(service_order)
+    if abs(line_total - service_order.total_price) > 0.01:
+        raise ValidationError(
+            "Total da OS diverge da soma dos itens: revise os valores antes da emissão da fatura"
+        )
+
+
 def validate_priced_lines(service_order: ServiceOrder) -> None:
     for line in service_order.service_lines:
         if line.unit_price is None or line.unit_price <= 0:

--- a/src/domain/service_order/entity.py
+++ b/src/domain/service_order/entity.py
@@ -49,6 +49,9 @@ class ServiceOrder:
     def set_priority(self, priority: Priority) -> None:
         self.priority = priority
 
+    def set_status(self, status: ServiceOrderStatus) -> None:
+        self.status = status
+
     def mark_delivered(self) -> None:
         if self.status != ServiceOrderStatus.FINALIZADA:
             raise ValidationError("OS deve estar finalizada para ser entregue")

--- a/src/domain/service_order/entity.py
+++ b/src/domain/service_order/entity.py
@@ -50,4 +50,6 @@ class ServiceOrder:
         self.priority = priority
 
     def mark_delivered(self) -> None:
+        if self.status != ServiceOrderStatus.FINALIZADA:
+            raise ValidationError("OS deve estar finalizada para ser entregue")
         self.status = ServiceOrderStatus.ENTREGUE

--- a/src/domain/service_order/entity.py
+++ b/src/domain/service_order/entity.py
@@ -49,7 +49,9 @@ class ServiceOrder:
     def set_priority(self, priority: Priority) -> None:
         self.priority = priority
 
-    def set_status(self, status: ServiceOrderStatus) -> None:
+    def override_status(self, status: ServiceOrderStatus, reason: str) -> None:
+        if not reason.strip():
+            raise ValidationError("Motivo da alteração de status é obrigatório")
         self.status = status
 
     def mark_delivered(self) -> None:

--- a/src/infrastructure/external/local_cpf.py
+++ b/src/infrastructure/external/local_cpf.py
@@ -1,0 +1,13 @@
+from validate_docbr import CPF
+
+from src.application.ports.cpf_validator import CpfValidationResult
+from src.domain.exceptions import ValidationError
+
+
+class LocalCpfValidator:
+    """Validates CPF locally (validate_docbr) without calling Invertexto API."""
+
+    def validate(self, cpf: str) -> CpfValidationResult:
+        if not CPF().validate(cpf):
+            raise ValidationError("CPF inválido")
+        return CpfValidationResult(valid=True, formatted=CPF().mask(cpf))

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -477,6 +477,25 @@ def test_full_flow(client, auth_headers):
     assert updated_os.status_code == 200
     assert updated_os.json()["mechanic_name"] == "Carlos Silva"
     assert updated_os.json()["priority"] == "Urgente"
+    assert updated_os.json()["status"] == "Em diagnóstico"
+
+    generic_status_update = client.put(
+        f"/api/v1/admin/service-orders/{os_id}",
+        headers=auth_headers,
+        json={"status": "Finalizada"},
+    )
+    assert generic_status_update.status_code == 422
+
+    status_override = client.patch(
+        f"/api/v1/admin/service-orders/{os_id}/status-override",
+        headers=auth_headers,
+        json={
+            "status": "Em diagnóstico",
+            "reason": "Correção administrativa no fluxo de teste",
+        },
+    )
+    assert status_override.status_code == 200
+    assert status_override.json()["status"] == "Em diagnóstico"
 
     no_op_update = client.put(
         f"/api/v1/admin/service-orders/{os_id}",

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -505,6 +505,7 @@ def test_full_flow(client, auth_headers):
         headers=auth_headers,
     )
     assert invoice.status_code == 201
+    assert invoice.json()["amount"] == 160.0
 
     invoice_lookup = client.get(
         f"/api/v1/admin/service-orders/{os_id}/invoice",
@@ -519,6 +520,12 @@ def test_full_flow(client, auth_headers):
     )
     assert paid.status_code == 200
     assert paid.json()["status"] == "Paga"
+
+    deliver = client.patch(
+        f"/api/v1/admin/service-orders/{os_id}/deliver",
+        headers=auth_headers,
+    )
+    assert deliver.status_code == 422
 
     track = client.get(
         f"/api/v1/public/service-orders/{os_id}?document=52998224725"

--- a/tests/unit/billing/test_billing_domain.py
+++ b/tests/unit/billing/test_billing_domain.py
@@ -1,7 +1,11 @@
 from datetime import datetime
 
+import pytest
+
 from src.domain.billing.entity import Invoice
-from src.domain.enums import InvoiceStatus
+from src.domain.enums import InvoiceStatus, ServiceOrderStatus
+from src.domain.exceptions import ValidationError
+from src.domain.service_order.entity import ServiceOrder
 
 
 def test_invoice_create_defaults_to_pending_status():
@@ -21,3 +25,39 @@ def test_invoice_pay_sets_status_and_paid_at():
 
     assert invoice.status == InvoiceStatus.PAID
     assert invoice.paid_at == paid_at
+
+
+def test_invoice_pay_rejects_already_paid():
+    paid_at = datetime(2026, 1, 1, 10, 0, 0)
+    invoice = Invoice.create(service_order_id=1, amount=150.0)
+    invoice.pay(paid_at)
+
+    with pytest.raises(ValidationError, match="Fatura já está paga"):
+        invoice.pay(paid_at)
+
+
+def test_mark_delivered_requires_finalized_status():
+    service_order = ServiceOrder(
+        id=1,
+        budget_id=2,
+        customer_id=3,
+        vehicle_id=4,
+        status=ServiceOrderStatus.EM_EXECUCAO,
+    )
+
+    with pytest.raises(ValidationError, match="OS deve estar finalizada para ser entregue"):
+        service_order.mark_delivered()
+
+
+def test_mark_delivered_sets_entregue_from_finalizada():
+    service_order = ServiceOrder(
+        id=1,
+        budget_id=2,
+        customer_id=3,
+        vehicle_id=4,
+        status=ServiceOrderStatus.FINALIZADA,
+    )
+
+    service_order.mark_delivered()
+
+    assert service_order.status == ServiceOrderStatus.ENTREGUE

--- a/tests/unit/billing/test_billing_rules.py
+++ b/tests/unit/billing/test_billing_rules.py
@@ -1,7 +1,11 @@
 import pytest
 from dataclasses import replace
 
-from src.domain.billing.rules import calculate_invoice_amount, validate_priced_lines
+from src.domain.billing.rules import (
+    calculate_invoice_amount,
+    validate_invoice_total_matches_lines,
+    validate_priced_lines,
+)
 from src.domain.enums import ServiceOrderStatus
 from src.domain.exceptions import ValidationError
 from src.domain.service_order.entity import (
@@ -18,6 +22,7 @@ def _service_order(**overrides) -> ServiceOrder:
         customer_id=3,
         vehicle_id=4,
         status=ServiceOrderStatus.FINALIZADA,
+        total_price=130.0,
         service_lines=[
             ServiceOrderServiceLine(
                 id=1,
@@ -80,3 +85,10 @@ def test_validate_priced_lines_rejects_zero_product_price():
 
     with pytest.raises(ValidationError, match="precificação válida"):
         validate_priced_lines(order)
+
+
+def test_validate_invoice_total_matches_lines_rejects_divergent_total():
+    order = _service_order(total_price=999.0)
+
+    with pytest.raises(ValidationError, match="Total da OS diverge"):
+        validate_invoice_total_matches_lines(order)

--- a/tests/unit/billing/test_billing_rules.py
+++ b/tests/unit/billing/test_billing_rules.py
@@ -1,0 +1,82 @@
+import pytest
+from dataclasses import replace
+
+from src.domain.billing.rules import calculate_invoice_amount, validate_priced_lines
+from src.domain.enums import ServiceOrderStatus
+from src.domain.exceptions import ValidationError
+from src.domain.service_order.entity import (
+    ServiceOrder,
+    ServiceOrderProductLine,
+    ServiceOrderServiceLine,
+)
+
+
+def _service_order(**overrides) -> ServiceOrder:
+    base = ServiceOrder(
+        id=1,
+        budget_id=2,
+        customer_id=3,
+        vehicle_id=4,
+        status=ServiceOrderStatus.FINALIZADA,
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=2,
+                unit_price=50.0,
+            )
+        ],
+        product_lines=[
+            ServiceOrderProductLine(
+                id=1,
+                service_order_id=1,
+                product_id=20,
+                quantity=3,
+                unit_price=10.0,
+            )
+        ],
+    )
+    return replace(base, **overrides)
+
+
+def test_calculate_invoice_amount_sums_service_and_product_lines():
+    amount = calculate_invoice_amount(_service_order())
+
+    assert amount == 130.0
+
+
+def test_validate_priced_lines_rejects_zero_service_price():
+    order = _service_order(
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=1,
+                unit_price=0.0,
+            )
+        ],
+        product_lines=[],
+    )
+
+    with pytest.raises(ValidationError, match="precificação válida"):
+        validate_priced_lines(order)
+
+
+def test_validate_priced_lines_rejects_zero_product_price():
+    order = _service_order(
+        service_lines=[],
+        product_lines=[
+            ServiceOrderProductLine(
+                id=1,
+                service_order_id=1,
+                product_id=20,
+                quantity=1,
+                unit_price=0.0,
+            )
+        ],
+    )
+
+    with pytest.raises(ValidationError, match="precificação válida"):
+        validate_priced_lines(order)

--- a/tests/unit/billing/test_billing_service.py
+++ b/tests/unit/billing/test_billing_service.py
@@ -7,7 +7,7 @@ from src.application.services.invoice_service import InvoiceService
 from src.domain.billing.entity import Invoice
 from src.domain.enums import InvoiceStatus, ServiceOrderStatus
 from src.domain.exceptions import NotFoundError, ValidationError
-from src.domain.service_order.entity import ServiceOrder
+from src.domain.service_order.entity import ServiceOrder, ServiceOrderServiceLine
 
 
 class InMemoryInvoiceRepository:
@@ -103,6 +103,15 @@ def make_service_order(**overrides) -> ServiceOrder:
         vehicle_id=4,
         status=ServiceOrderStatus.FINALIZADA,
         total_price=150.0,
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=1,
+                unit_price=150.0,
+            )
+        ],
     )
     return replace(base, **overrides)
 
@@ -242,3 +251,55 @@ def test_invoice_service_rejects_deliver_without_paid_invoice():
 
     with pytest.raises(ValidationError, match="Fatura deve estar paga para entregar a OS"):
         service.deliver(1)
+
+
+def test_invoice_service_calculates_amount_from_lines():
+    service_order = make_service_order(
+        total_price=999.0,
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=2,
+                unit_price=40.0,
+            )
+        ],
+        product_lines=[],
+    )
+    service = make_service(
+        service_orders=InMemoryServiceOrderRepository([service_order])
+    )
+
+    invoice = service.create_invoice(1)
+
+    assert invoice.amount == 80.0
+
+
+def test_invoice_service_rejects_unpriced_lines():
+    service_order = make_service_order(
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=1,
+                unit_price=0.0,
+            )
+        ],
+    )
+    service = make_service(
+        service_orders=InMemoryServiceOrderRepository([service_order])
+    )
+
+    with pytest.raises(ValidationError, match="precificação válida"):
+        service.create_invoice(1)
+
+
+def test_invoice_service_rejects_duplicate_payment():
+    invoice = Invoice(id=1, service_order_id=1, amount=150.0)
+    invoice.pay(datetime(2026, 1, 1, 10, 0, 0))
+    service = make_service(invoices=InMemoryInvoiceRepository([invoice]))
+
+    with pytest.raises(ValidationError, match="Fatura já está paga"):
+        service.pay_invoice(1)

--- a/tests/unit/billing/test_billing_service.py
+++ b/tests/unit/billing/test_billing_service.py
@@ -255,7 +255,7 @@ def test_invoice_service_rejects_deliver_without_paid_invoice():
 
 def test_invoice_service_calculates_amount_from_lines():
     service_order = make_service_order(
-        total_price=999.0,
+        total_price=80.0,
         service_lines=[
             ServiceOrderServiceLine(
                 id=1,
@@ -274,6 +274,28 @@ def test_invoice_service_calculates_amount_from_lines():
     invoice = service.create_invoice(1)
 
     assert invoice.amount == 80.0
+
+
+def test_invoice_service_rejects_total_that_diverges_from_lines():
+    service_order = make_service_order(
+        total_price=999.0,
+        service_lines=[
+            ServiceOrderServiceLine(
+                id=1,
+                service_order_id=1,
+                service_id=10,
+                quantity=2,
+                unit_price=40.0,
+            )
+        ],
+        product_lines=[],
+    )
+    service = make_service(
+        service_orders=InMemoryServiceOrderRepository([service_order])
+    )
+
+    with pytest.raises(ValidationError, match="Total da OS diverge"):
+        service.create_invoice(1)
 
 
 def test_invoice_service_rejects_unpriced_lines():

--- a/tests/unit/budget_approval/test_budget_approval_service.py
+++ b/tests/unit/budget_approval/test_budget_approval_service.py
@@ -229,6 +229,35 @@ def test_approve_budget_rejects_missing_token():
         service.approve_budget("missing")
 
 
+def test_approve_budget_rejects_budget_without_lines():
+    budget = replace(
+        make_budget(),
+        status=BudgetStatus.SENT,
+        approval_token="token-1",
+        service_lines=[],
+        product_lines=[],
+    )
+    service = make_service(repository=InMemoryBudgetRepository([budget]))
+
+    with pytest.raises(
+        ValidationError,
+        match="Orçamento deve ter linhas de serviço ou produto para ser aprovado",
+    ):
+        service.approve_budget("token-1")
+
+
+def test_approve_budget_rejects_rejected_budget():
+    budget = replace(
+        make_budget(),
+        status=BudgetStatus.REJECTED,
+        approval_token="token-1",
+    )
+    service = make_service(repository=InMemoryBudgetRepository([budget]))
+
+    with pytest.raises(ValidationError, match="Orçamento recusado não pode ser aprovado"):
+        service.approve_budget("token-1")
+
+
 def test_approve_budget_rejects_already_approved_budget_without_commit():
     budget = replace(make_budget(), status=BudgetStatus.APPROVED, approval_token="token-1")
     repository = InMemoryBudgetRepository([budget])

--- a/tests/unit/budget_approval/test_budget_approval_service.py
+++ b/tests/unit/budget_approval/test_budget_approval_service.py
@@ -247,6 +247,43 @@ def test_approve_budget_rejects_already_approved_budget_without_commit():
     assert uow.commits == 0
 
 
+def test_approve_budget_by_id_creates_service_order():
+    budget = make_budget()
+    repository = InMemoryBudgetRepository([budget])
+    service_orders = FakeServiceOrderCreator()
+    uow = FakeUnitOfWork()
+    service = make_service(
+        repository=repository,
+        service_orders=service_orders,
+        uow=uow,
+    )
+
+    service_order = service.approve_budget_by_id(1)
+
+    assert service_order.id == 99
+    assert repository.get_by_id(1).status == BudgetStatus.APPROVED
+    assert uow.commits == 1
+
+
+def test_approve_budget_by_id_rejects_budget_without_lines():
+    budget = replace(make_budget(), service_lines=[], product_lines=[])
+    service = make_service(repository=InMemoryBudgetRepository([budget]))
+
+    with pytest.raises(
+        ValidationError,
+        match="Orçamento deve ter linhas de serviço ou produto para ser aprovado",
+    ):
+        service.approve_budget_by_id(1)
+
+
+def test_approve_budget_by_id_rejects_rejected_budget():
+    budget = replace(make_budget(), status=BudgetStatus.REJECTED)
+    service = make_service(repository=InMemoryBudgetRepository([budget]))
+
+    with pytest.raises(ValidationError, match="Orçamento recusado não pode ser aprovado"):
+        service.approve_budget_by_id(1)
+
+
 def test_reject_budget_marks_budget_rejected():
     budget = replace(make_budget(), status=BudgetStatus.SENT, approval_token="token-1")
     repository = InMemoryBudgetRepository([budget])

--- a/tests/unit/infrastructure/test_local_cpf.py
+++ b/tests/unit/infrastructure/test_local_cpf.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.application.ports.cpf_validator import CpfValidationResult
+from src.domain.exceptions import ValidationError
+from src.infrastructure.external.local_cpf import LocalCpfValidator
+
+
+def test_local_cpf_validator_accepts_valid_cpf():
+    result = LocalCpfValidator().validate("52998224725")
+
+    assert result == CpfValidationResult(valid=True, formatted="529.982.247-25")
+
+
+def test_local_cpf_validator_rejects_invalid_cpf():
+    with pytest.raises(ValidationError, match="CPF inválido"):
+        LocalCpfValidator().validate("11111111111")

--- a/tests/unit/service_order/test_service_order_service.py
+++ b/tests/unit/service_order/test_service_order_service.py
@@ -205,17 +205,28 @@ def test_service_order_service_updates_status_manually():
     uow = FakeUnitOfWork()
     service = make_service(repository=repository, uow=uow)
 
-    updated = service.update(1, status=ServiceOrderStatus.FINALIZADA)
+    updated = service.override_status(
+        1,
+        ServiceOrderStatus.FINALIZADA,
+        "Correção administrativa",
+    )
 
     assert updated.status == ServiceOrderStatus.FINALIZADA
     assert repository.get_by_id(1).status == ServiceOrderStatus.FINALIZADA
     assert uow.commits == 1
 
 
-def test_service_order_entity_set_status():
+def test_service_order_entity_override_status_requires_reason():
     service_order = make_service_order(status=ServiceOrderStatus.AGUARDANDO_APROVACAO)
 
-    service_order.set_status(ServiceOrderStatus.EM_EXECUCAO)
+    with pytest.raises(ValidationError, match="Motivo"):
+        service_order.override_status(ServiceOrderStatus.EM_EXECUCAO, " ")
+
+
+def test_service_order_entity_override_status():
+    service_order = make_service_order(status=ServiceOrderStatus.AGUARDANDO_APROVACAO)
+
+    service_order.override_status(ServiceOrderStatus.EM_EXECUCAO, "Correção administrativa")
 
     assert service_order.status == ServiceOrderStatus.EM_EXECUCAO
 

--- a/tests/unit/service_order/test_service_order_service.py
+++ b/tests/unit/service_order/test_service_order_service.py
@@ -198,6 +198,28 @@ def test_service_order_service_updates_order_and_commits():
     assert uow.commits == 1
 
 
+def test_service_order_service_updates_status_manually():
+    repository = InMemoryServiceOrderRepository(
+        [make_service_order(status=ServiceOrderStatus.AGUARDANDO_APROVACAO)]
+    )
+    uow = FakeUnitOfWork()
+    service = make_service(repository=repository, uow=uow)
+
+    updated = service.update(1, status=ServiceOrderStatus.FINALIZADA)
+
+    assert updated.status == ServiceOrderStatus.FINALIZADA
+    assert repository.get_by_id(1).status == ServiceOrderStatus.FINALIZADA
+    assert uow.commits == 1
+
+
+def test_service_order_entity_set_status():
+    service_order = make_service_order(status=ServiceOrderStatus.AGUARDANDO_APROVACAO)
+
+    service_order.set_status(ServiceOrderStatus.EM_EXECUCAO)
+
+    assert service_order.status == ServiceOrderStatus.EM_EXECUCAO
+
+
 def test_service_order_service_sets_priority_and_commits():
     repository = InMemoryServiceOrderRepository([make_service_order()])
     uow = FakeUnitOfWork()


### PR DESCRIPTION
## Resumo da branch `feature/t11-faturamento-encerramento-pagamento`

Branch focada na **T11 — Faturamento e encerramento por pagamento** (RF38–RF40), com melhorias de UX e suporte ao desenvolvimento local. São **4 commits** à frente da `main`.

---

### Objetivo principal (T11)

Implementar o fluxo MVP de faturamento:

1. **Criar fatura** a partir de uma OS **Finalizada**
2. **Registrar pagamento** da fatura
3. **Marcar OS como Entregue** após o pagamento

**Escopo deliberadamente limitado:** sem pagamentos parciais, sem entidade `Payment`, sem eventos de domínio.

---

### Backend

**Regras de domínio (`billing/rules.py`)**
- Cálculo do valor da fatura (soma `preço × quantidade` das linhas)
- Validação de linhas com preço nulo ou zero

**Entidades**
- `Invoice.pay()` — impede pagar fatura já paga
- `ServiceOrder.mark_delivered()` — exige status `Finalizada`
- `ServiceOrder.set_status()` — override manual de status (admin)

**API**
- `POST /api/v1/admin/service-orders/{id}/invoice` — criar fatura
- `PATCH /api/v1/admin/invoices/{id}/pay` — registrar pagamento
- `PATCH /api/v1/admin/service-orders/{id}/deliver` — entregar OS
- `PATCH /api/v1/admin/budgets/{id}/approve` — aprovar orçamento (cria a OS)

**Dev local**
- `LocalCpfValidator` — validação de CPF só com `validate_docbr`, sem API externa
- Flag `SKIP_CPF_EXTERNAL_VALIDATION` em `config.py` e `.env.example`

---

### Frontend

**Detalhe da OS** — seção **Faturamento**: criar fatura, pagar, mensagens de erro da API; correção para não repetir `GET .../invoice` com 404 quando ainda não existe fatura.

**Detalhe do orçamento** — botão **Aprovar orçamento** (dispara criação da OS).

**Editar OS** — dropdown de **status** manual (salvo com “Salvar alterações”).

---

### Testes e documentação

- Testes unitários de billing, aprovação de orçamento, status da OS e CPF local
- Testes de integração atualizados
- RF38–RF40 marcados em `docs/tasks.md`
- Seção de faturamento no `README.md`

---

### Fluxo E2E esperado

```
Orçamento → Aprovar → OS criada → Finalizar OS → Criar fatura → Pagar → Entregar
```

---

### Commits na branch

| Commit | Descrição |
|--------|-----------|
| `97a414b` | T11: hardening do faturamento e encerramento (RF38–RF40) |
| `7215ab3` | Aprovação de orçamento no admin + validação local de CPF |
| `bddeb3f` | Alteração manual de status da OS na UI |
| `cb06d99` | Evita requisições repetidas de invoice 404 |

---

### Fora do escopo (não implementado)

Pagamentos parciais, métodos de pagamento, entidade `Payment`, eventos de domínio, descontos no orçamento e renomear `Pendente` → `Aguardando Pagamento`.