### PR TITLE
Infraestrutura Kubernetes com Terraform

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,6 +75,34 @@ jobs:
             done
           done
 
+  terraform-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.30.0
+          node_image: kindest/node:v1.34.0
+          cluster_name: kind
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.16.0"
+      - name: Validate Terraform formatting and configuration
+        run: |
+          set -euo pipefail
+          terraform -chdir=infra init -backend=false -input=false
+          terraform -chdir=infra fmt -check -recursive
+          terraform -chdir=infra validate
+      - name: Plan local Kubernetes stack
+        run: |
+          set -euo pipefail
+          terraform -chdir=infra plan \
+            -input=false \
+            -refresh=false \
+            -var-file=terraform.tfvars.example \
+            -var=kube_context=kind-kind \
+            -out=terraform.tfplan
+
   cluster-smoke:
     runs-on: ubuntu-latest
     needs: [test-and-security, manifests]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,15 +93,90 @@ jobs:
           terraform -chdir=infra init -backend=false -input=false
           terraform -chdir=infra fmt -check -recursive
           terraform -chdir=infra validate
-      - name: Plan local Kubernetes stack
+      - name: Plan and verify every Terraform environment
         run: |
           set -euo pipefail
-          terraform -chdir=infra plan \
-            -input=false \
-            -refresh=false \
-            -var-file=terraform.tfvars.example \
-            -var=kube_context=kind-kind \
-            -out=terraform.tfplan
+          secure_image="ghcr.io/example/auto-shop-system@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+          plan_and_check() {
+            environment="$1"
+            shift
+            plan_file="$(mktemp)"
+            plan_json="$(mktemp)"
+            trap 'rm -f "$plan_file" "$plan_json"' RETURN
+
+            terraform -chdir=infra plan \
+              -input=false \
+              -refresh=false \
+              -var-file=terraform.tfvars.example \
+              -var=kube_context=kind-kind \
+              "$@" \
+              -out="$plan_file"
+            terraform -chdir=infra show -json "$plan_file" > "$plan_json"
+
+            jq -e '
+              [.resource_changes[].address] as $addresses
+              | [
+                  "kubernetes_namespace_v1.auto_shop",
+                  "kubernetes_config_map_v1.app",
+                  "kubernetes_job_v1.migration",
+                  "kubernetes_deployment_v1.backend",
+                  "kubernetes_service_v1.backend",
+                  "kubernetes_horizontal_pod_autoscaler_v2.backend",
+                  "kubernetes_ingress_v1.backend[0]"
+                ]
+              | all(. as $address | $addresses | index($address) != null)
+            ' "$plan_json"
+
+            postgres_count="$(jq '[.resource_changes[].address | select(test("^kubernetes_(persistent_volume_claim_v1|deployment_v1|service_v1)\\.postgres\\[0\\]$"))] | length' "$plan_json")"
+            if [[ "$environment" == "local" ]]; then
+              [[ "$postgres_count" -eq 3 ]] || {
+                echo "Local plan must contain PVC, Deployment, and Service for PostgreSQL; found $postgres_count"
+                exit 1
+              }
+            else
+              [[ "$postgres_count" -eq 0 ]] || {
+                echo "$environment plan must not contain local PostgreSQL resources; found $postgres_count"
+                exit 1
+              }
+            fi
+          }
+
+          plan_and_check local \
+            -var=environment=local \
+            -var=enable_local_database=true
+
+          plan_and_check staging \
+            -var=environment=staging \
+            -var=app_env=staging \
+            -var=image_reference="$secure_image" \
+            -var=app_base_url=https://api.staging.example.com \
+            -var=frontend_public_url=https://staging.example.com \
+            -var=cors_allowed_origins=https://staging.example.com \
+            -var=security_hsts_enabled=true \
+            -var=smtp_host=smtp.staging.example.com \
+            -var=smtp_use_tls=true \
+            -var=smtp_starttls=true \
+            -var=smtp_require_tls=true \
+            -var=skip_cpf_external_validation=false \
+            -var=ingress_host=api.staging.example.com \
+            -var=enable_local_database=false
+
+          plan_and_check production \
+            -var=environment=production \
+            -var=app_env=production \
+            -var=image_reference="$secure_image" \
+            -var=app_base_url=https://api.example.com \
+            -var=frontend_public_url=https://example.com \
+            -var=cors_allowed_origins=https://example.com \
+            -var=security_hsts_enabled=true \
+            -var=smtp_host=smtp.example.com \
+            -var=smtp_use_tls=true \
+            -var=smtp_starttls=true \
+            -var=smtp_require_tls=true \
+            -var=skip_cpf_external_validation=false \
+            -var=ingress_host=api.example.com \
+            -var=enable_local_database=false
 
   cluster-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -84,6 +84,14 @@ jobs:
           version: v0.30.0
           node_image: kindest/node:v1.34.0
           cluster_name: kind
+      - name: Configure kubeconfig for Terraform
+        run: |
+          set -euo pipefail
+          kubeconfig_path="$RUNNER_TEMP/kind-kubeconfig"
+          kind get kubeconfig --name kind > "$kubeconfig_path"
+          echo "KUBECONFIG=$kubeconfig_path" >> "$GITHUB_ENV"
+          kubectl --kubeconfig="$kubeconfig_path" config get-contexts
+          kubectl --kubeconfig="$kubeconfig_path" config use-context kind-kind
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.16.0"
@@ -109,6 +117,7 @@ jobs:
               -input=false \
               -refresh=false \
               -var-file=terraform.tfvars.example \
+              -var=kubeconfig_path="$KUBECONFIG" \
               -var=kube_context=kind-kind \
               "$@" \
               -out="$plan_file"

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ k8s/secrets.yaml
 k8s/secret.yaml
 k8s/overlays/**/secrets.env
 k8s/overlays/**/.env
+
+# Terraform local state and generated files
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+infra/terraform.tfvars

--- a/README.md
+++ b/README.md
@@ -246,7 +246,15 @@ Interface vanilla servida pelo FastAPI em `/app/`:
 
 ## Deploy por ambiente
 
-O fluxo operacional seguro está documentado em [docs/deployment.md](docs/deployment.md). O deploy Kubernetes usa as fases independentes `foundation -> migration -> app -> ingress`; a API só recebe tráfego depois que a migration termina e o readiness check confirma o PostgreSQL.
+O fluxo operacional seguro está documentado em [docs/deployment.md](docs/deployment.md). O projeto possui dois caminhos alternativos para Kubernetes:
+
+- [Kustomize](docs/deployment.md): fluxo existente com as fases independentes `foundation -> migration -> app -> ingress`.
+- [Terraform](infra/README.md): alternativa declarativa para gerenciar a stack completa em um cluster já existente.
+
+Escolha um único proprietário por ambiente. Não aplique Terraform e Kustomize no
+mesmo namespace, pois os dois mecanismos gerenciam recursos com os mesmos nomes.
+Em ambos os fluxos, a API só recebe tráfego depois que a migration termina e o
+readiness check confirma o PostgreSQL.
 
 ## Hardening de OS e links publicos
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,7 +20,7 @@ execução é sempre `foundation`, `migration`, `app` e, quando necessário,
    arquivo de destino é ignorado pelo Git; `DATABASE_URL` é gerada a partir de
    `DB_NAME`, `DB_USER` e `DB_PASSWORD`.
 2. Confirme o contexto do Kind ou Docker Desktop com `kubectl config current-context`.
-3. Execute `./setup/Windows/setup.ps1 -Environment local` no PowerShell.
+3. Execute `./k8s/scripts/deploy.ps1 -Environment local` no PowerShell.
 
 O overlay local cria PostgreSQL com uma réplica e probes `pg_isready`, além do
 MailHog. O script constrói uma referência local única por execução e a carrega
@@ -50,9 +50,9 @@ provisione no namespace `auto-shop`:
 Use uma referência de imagem imutável, preferencialmente digest:
 
 ```powershell
-./setup/Windows/setup.ps1 -Environment staging `
+./k8s/scripts/deploy.ps1 -Environment staging `
   -ImageReference ghcr.io/example/auto-shop-system:0123456789abcdef0123456789abcdef01234567
-./setup/Windows/setup.ps1 -Environment production `
+./k8s/scripts/deploy.ps1 -Environment production `
   -ImageReference ghcr.io/example/auto-shop-system@sha256:<64-hex-digest> `
   -ConfirmProduction
 ```
@@ -67,6 +67,33 @@ connection string.
 Produção e staging usam HTTPS, HSTS e redirect de HTTP para HTTPS. O Secret TLS
 deve ser emitido por cert-manager ou provisionado por um processo externo; o
 script não cria certificados automaticamente.
+
+## Terraform (alternativa declarativa)
+
+O diretório [`infra/`](../infra/README.md) oferece uma alternativa ao Kustomize
+para gerenciar Namespace, ConfigMap, migration, backend, Service, HPA e Ingress
+em um cluster Kubernetes existente. Ele não provisiona AWS, EKS, VPC, IAM, RDS
+ou PostgreSQL externo.
+
+Use Terraform ou Kustomize por ambiente, nunca os dois simultaneamente no mesmo
+namespace. O Kustomize continua disponível para compatibilidade e para o fluxo
+operacional documentado acima; quando Terraform for escolhido, ele passa a ser
+o proprietário declarado dos recursos daquele ambiente.
+
+No Terraform:
+
+- o Secret `auto-shop-secrets` é criado previamente por um mecanismo externo e
+  nunca é armazenado no state;
+- `enable_local_database=true` é permitido somente em `local`;
+- staging e production usam PostgreSQL externo e devem manter
+  `enable_local_database=false`;
+- a imagem da API deve usar digest ou tag baseada em SHA;
+- o Job de migration é versionado pela imagem, aguarda conclusão antes do
+  Deployment e não possui TTL automático para não desaparecer do state.
+
+O passo a passo, incluindo imports para assumir um namespace já gerenciado pelo
+Kustomize e comandos específicos do PowerShell, está em
+[`infra/README.md`](../infra/README.md).
 
 ## Rollback e diagnóstico
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:1OF0rDUteVdoX04BrtmTc0T4NOo6+D0utmK6hM0EzZw=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,81 @@
+# Terraform para Kubernetes
+
+Este diretório oferece um caminho declarativo alternativo ao Kustomize para
+gerenciar a stack do Auto Shop em um cluster Kubernetes já existente. Ele não
+cria EKS, VPC, IAM, RDS ou qualquer recurso AWS.
+
+## Escopo
+
+O root gerencia namespace, ConfigMap, Job de migration, Deployment, Service,
+HPA e Ingress da aplicação. O PostgreSQL é criado apenas quando
+`enable_local_database = true`, opção destinada ao ambiente local.
+
+Staging e production continuam usando um banco externo. O Terraform não cria,
+atualiza ou lê valores de Secrets: o Secret `auto-shop-secrets` precisa existir
+antes do `plan`/`apply` com as chaves exigidas pela aplicação, incluindo
+`DATABASE_URL` e `SECRET_KEY`. Para o banco local, também são necessárias
+`DB_NAME`, `DB_USER` e `DB_PASSWORD`.
+
+Não aplique Terraform e Kustomize para os mesmos recursos no mesmo namespace.
+Escolha um único proprietário por ambiente para evitar drift e conflitos de
+ownership.
+
+## Configuração
+
+1. Instale Terraform 1.6 ou superior e configure um kubeconfig com acesso ao
+   cluster desejado.
+2. Copie `terraform.tfvars.example` para `terraform.tfvars` e ajuste apenas os
+   valores não sensíveis do ambiente.
+3. Crie `auto-shop-secrets` por um mecanismo externo e seguro. Nunca coloque
+   credenciais no arquivo `.tfvars` versionado.
+
+O provider usa `kubeconfig_path` e `kube_context` quando informados; quando
+omitidos, usa a configuração padrão do Kubernetes. O arquivo de state local,
+planfiles e tfvars reais são ignorados pelo Git.
+
+## Comandos
+
+```bash
+terraform -chdir=infra init -backend=false
+terraform -chdir=infra fmt -check -recursive
+terraform -chdir=infra validate
+terraform -chdir=infra plan -var-file=terraform.tfvars
+```
+
+Para o ambiente local, habilite explicitamente o banco:
+
+```bash
+terraform -chdir=infra plan \
+  -var-file=terraform.tfvars \
+  -var=environment=local \
+  -var=enable_local_database=true
+```
+
+`terraform apply` deve ser executado somente depois da revisão do plano e com
+o contexto Kubernetes confirmado por `kubectl config current-context`.
+
+## Recursos existentes
+
+Se o namespace ou os recursos já existirem, importe-os para o state antes do
+primeiro apply. O Job de migration é versionado pela imagem e normalmente deve
+ser criado pelo Terraform na primeira execução.
+
+```bash
+terraform -chdir=infra import kubernetes_namespace_v1.auto_shop auto-shop
+terraform -chdir=infra import kubernetes_config_map_v1.app auto-shop/auto-shop-config
+terraform -chdir=infra import kubernetes_deployment_v1.backend auto-shop/auto-shop-backend
+terraform -chdir=infra import kubernetes_service_v1.backend auto-shop/auto-shop-backend-service
+```
+
+Os IDs devem ser conferidos no cluster antes do import. Não importe recursos
+gerenciados por outro state Terraform.
+
+## Banco local
+
+Quando habilitado, `db.tf` cria o PVC `postgres-pvc`, o Deployment `postgres` e
+o Service `postgres-service`. As credenciais são lidas pelo Pod diretamente do
+Secret Kubernetes existente; elas não passam pelo Terraform state.
+
+O banco local é adequado para Kind/Docker Desktop e desenvolvimento. Staging e
+production devem apontar `DATABASE_URL` para um PostgreSQL externo e manter
+`enable_local_database = false`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -22,8 +22,9 @@ ownership.
 
 ## Configuração
 
-1. Instale Terraform 1.6 ou superior e configure um kubeconfig com acesso ao
-   cluster desejado.
+1. Instale Terraform 1.6 ou superior, `kubectl` e configure um kubeconfig com
+   acesso ao cluster desejado. Para desenvolvimento local, Kind ou Docker
+   Desktop também são opções válidas.
 2. Copie `terraform.tfvars.example` para `terraform.tfvars` e ajuste apenas os
    valores não sensíveis do ambiente.
 3. Crie `auto-shop-secrets` por um mecanismo externo e seguro. Nunca coloque
@@ -35,11 +36,20 @@ planfiles e tfvars reais são ignorados pelo Git.
 
 ## Comandos
 
+Use `-backend=false` apenas para validação sem backend. Para aplicar recursos,
+use `terraform init` normal antes do primeiro `plan` ou `apply`.
+
 ```bash
-terraform -chdir=infra init -backend=false
+terraform -chdir=infra init
 terraform -chdir=infra fmt -check -recursive
 terraform -chdir=infra validate
 terraform -chdir=infra plan -var-file=terraform.tfvars
+```
+
+Para validar sem configurar backend:
+
+```bash
+terraform -chdir=infra init -backend=false
 ```
 
 Para o ambiente local, habilite explicitamente o banco:
@@ -54,21 +64,137 @@ terraform -chdir=infra plan \
 `terraform apply` deve ser executado somente depois da revisão do plano e com
 o contexto Kubernetes confirmado por `kubectl config current-context`.
 
+### PowerShell e primeiro ambiente local
+
+Em um namespace novo, o Secret só pode ser criado depois que o Namespace
+existir. Faça um bootstrap somente do Namespace, crie o Secret externamente e
+depois execute o apply completo. O array abaixo evita que o PowerShell divida
+endereços Terraform ou argumentos com `=`:
+
+```powershell
+$namespace = "auto-shop-tf-test"
+$kubeconfig = Join-Path $env:USERPROFILE ".kube\config"
+$env:KUBECONFIG = $kubeconfig
+
+$bootstrapArguments = @(
+  "-chdir=infra"
+  "apply"
+  "-auto-approve"
+  "-target=kubernetes_namespace_v1.auto_shop"
+  "-var-file=terraform.tfvars.example"
+  "-var=namespace=$namespace"
+  "-var=kubeconfig_path=$kubeconfig"
+  "-var=kube_context=kind-kind"
+)
+
+terraform @bootstrapArguments
+```
+
+Crie o Secret no namespace usando um mecanismo externo. Para um teste local,
+credenciais efêmeras podem ser geradas na sessão do PowerShell:
+
+```powershell
+$dbPassword = [guid]::NewGuid().ToString("N")
+$secretKey = [guid]::NewGuid().ToString("N")
+
+kubectl create secret generic auto-shop-secrets `
+  --namespace $namespace `
+  --from-literal="DATABASE_URL=postgresql://oficina:$dbPassword@postgres-service:5432/oficina" `
+  --from-literal="DB_NAME=oficina" `
+  --from-literal="DB_USER=oficina" `
+  --from-literal="DB_PASSWORD=$dbPassword" `
+  --from-literal="SECRET_KEY=$secretKey" `
+  --from-literal="INVERTEXTO_API_TOKEN=local-ci-token" `
+  --from-literal="SMTP_USER=" `
+  --from-literal="SMTP_PASSWORD="
+```
+
+Execute então o apply completo, sem `-target`:
+
+```powershell
+$applyArguments = @(
+  "-chdir=infra"
+  "apply"
+  "-auto-approve"
+  "-var-file=terraform.tfvars.example"
+  "-var=namespace=$namespace"
+  "-var=kubeconfig_path=$kubeconfig"
+  "-var=kube_context=kind-kind"
+  "-var=enable_local_database=true"
+)
+
+terraform @applyArguments
+```
+
+O `StorageClass` local pode usar `WaitForFirstConsumer`. Por isso, o PVC pode
+ficar inicialmente `Pending` até o Deployment PostgreSQL ser criado; isso é
+esperado. O Terraform não deve aguardar o PVC antes de criar seu primeiro
+consumidor.
+
+Valide o resultado com:
+
+```powershell
+kubectl get pods,jobs,pvc,svc,hpa,ingress --namespace $namespace
+terraform -chdir=infra plan `
+  -var-file terraform.tfvars.example `
+  -var "namespace=$namespace" `
+  -var "kubeconfig_path=$kubeconfig" `
+  -var "kube_context=kind-kind" `
+  -var "enable_local_database=true"
+```
+
+Após um apply bem-sucedido, o segundo plano deve retornar `No changes`. Em Kind,
+os campos de métricas do HPA podem aparecer como `unknown` se o Metrics Server
+não estiver instalado; o recurso ainda estará criado com as metas configuradas.
+
 ## Recursos existentes
 
 Se o namespace ou os recursos já existirem, importe-os para o state antes do
 primeiro apply. O Job de migration é versionado pela imagem e normalmente deve
-ser criado pelo Terraform na primeira execução.
+ser criado pelo Terraform na primeira execução. O Job não possui TTL automático:
+isso evita que o Kubernetes o remova enquanto ele ainda está registrado no state.
+Jobs antigos podem ser limpos manualmente somente depois de confirmar que não
+estão associados ao state ativo.
 
 ```bash
 terraform -chdir=infra import kubernetes_namespace_v1.auto_shop auto-shop
 terraform -chdir=infra import kubernetes_config_map_v1.app auto-shop/auto-shop-config
+terraform -chdir=infra import kubernetes_job_v1.migration auto-shop/auto-shop-migrate-<hash-da-imagem>
 terraform -chdir=infra import kubernetes_deployment_v1.backend auto-shop/auto-shop-backend
 terraform -chdir=infra import kubernetes_service_v1.backend auto-shop/auto-shop-backend-service
+terraform -chdir=infra import kubernetes_horizontal_pod_autoscaler_v2.backend auto-shop/auto-shop-backend-hpa
+terraform -chdir=infra import 'kubernetes_ingress_v1.backend[0]' auto-shop/auto-shop-ingress
 ```
 
 Os IDs devem ser conferidos no cluster antes do import. Não importe recursos
-gerenciados por outro state Terraform.
+gerenciados por outro state Terraform. O endereço do Job é derivado de
+`substr(sha256(image_reference), 0, 12)`; use a mesma referência de imagem que
+será configurada no `terraform.tfvars`.
+
+Quando o banco local já existir, importe também os recursos condicionais:
+
+```bash
+terraform -chdir=infra import 'kubernetes_persistent_volume_claim_v1.postgres[0]' auto-shop/postgres-pvc
+terraform -chdir=infra import 'kubernetes_deployment_v1.postgres[0]' auto-shop/postgres
+terraform -chdir=infra import 'kubernetes_service_v1.postgres[0]' auto-shop/postgres-service
+```
+
+Use esta sequência para assumir um ambiente atualmente gerenciado pelo
+Kustomize:
+
+1. Pare os deploys Kustomize do ambiente e não aplique mais nenhuma fase nesse
+   namespace.
+2. Configure o Terraform com os mesmos nomes, imagem e valores não sensíveis
+   usados pelo ambiente atual.
+3. Importe todos os recursos existentes, incluindo os recursos condicionais do
+   banco local quando aplicável.
+4. Execute `terraform plan` e revise qualquer alteração ou destruição antes do
+   primeiro `apply`.
+5. Depois da validação, mantenha apenas o Terraform como proprietário daquele
+   ambiente.
+
+Em um namespace novo, os imports não são necessários. O Terraform criará os
+recursos diretamente, desde que o Secret exigido já exista.
 
 ## Banco local
 

--- a/infra/db.tf
+++ b/infra/db.tf
@@ -1,0 +1,179 @@
+resource "kubernetes_persistent_volume_claim_v1" "postgres" {
+  count = var.enable_local_database ? 1 : 0
+
+  metadata {
+    name      = "postgres-pvc"
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.database_labels
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+
+    resources {
+      requests = {
+        storage = var.postgres_storage
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "postgres" {
+  count = var.enable_local_database ? 1 : 0
+
+  metadata {
+    name      = "postgres"
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.database_labels
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "Recreate"
+    }
+
+    selector {
+      match_labels = {
+        app = "postgres"
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.database_labels
+      }
+
+      spec {
+        termination_grace_period_seconds = 60
+
+        container {
+          name              = "postgres"
+          image             = var.postgres_image
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            name           = "postgres"
+            container_port = 5432
+          }
+
+          env {
+            name = "POSTGRES_DB"
+
+            value_from {
+              secret_key_ref {
+                name = var.secret_name
+                key  = "DB_NAME"
+              }
+            }
+          }
+
+          env {
+            name = "POSTGRES_USER"
+
+            value_from {
+              secret_key_ref {
+                name = var.secret_name
+                key  = "DB_USER"
+              }
+            }
+          }
+
+          env {
+            name = "POSTGRES_PASSWORD"
+
+            value_from {
+              secret_key_ref {
+                name = var.secret_name
+                key  = "DB_PASSWORD"
+              }
+            }
+          }
+
+          volume_mount {
+            name       = "postgres-data"
+            mount_path = "/var/lib/postgresql/data"
+          }
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+          }
+
+          startup_probe {
+            exec {
+              command = ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+            }
+
+            period_seconds    = 5
+            timeout_seconds   = 3
+            failure_threshold = 30
+          }
+
+          readiness_probe {
+            exec {
+              command = ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+            }
+
+            period_seconds    = 5
+            timeout_seconds   = 3
+            failure_threshold = 3
+          }
+
+          liveness_probe {
+            exec {
+              command = ["sh", "-c", "pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
+            }
+
+            initial_delay_seconds = 15
+            period_seconds        = 15
+            timeout_seconds       = 3
+            failure_threshold     = 3
+          }
+        }
+
+        volume {
+          name = "postgres-data"
+
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim_v1.postgres[0].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_persistent_volume_claim_v1.postgres]
+}
+
+resource "kubernetes_service_v1" "postgres" {
+  count = var.enable_local_database ? 1 : 0
+
+  metadata {
+    name      = "postgres-service"
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.database_labels
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      app = "postgres"
+    }
+
+    port {
+      name        = "postgres"
+      port        = 5432
+      target_port = "postgres"
+    }
+  }
+}

--- a/infra/db.tf
+++ b/infra/db.tf
@@ -1,6 +1,10 @@
 resource "kubernetes_persistent_volume_claim_v1" "postgres" {
   count = var.enable_local_database ? 1 : 0
 
+  # WaitForFirstConsumer requires the database Pod to exist before the claim
+  # can be bound. The Deployment below is the first consumer of this PVC.
+  wait_until_bound = false
+
   metadata {
     name      = "postgres-pvc"
     namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name

--- a/infra/k8s.tf
+++ b/infra/k8s.tf
@@ -1,0 +1,414 @@
+resource "kubernetes_namespace_v1" "auto_shop" {
+  metadata {
+    name   = var.namespace
+    labels = local.common_labels
+  }
+}
+
+resource "kubernetes_config_map_v1" "app" {
+  metadata {
+    name      = local.config_map_name
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.common_labels
+  }
+
+  data = {
+    APP_ENV                      = var.app_env
+    APP_BASE_URL                 = var.app_base_url
+    FRONTEND_PUBLIC_URL          = var.frontend_public_url
+    CORS_ALLOWED_ORIGINS         = var.cors_allowed_origins
+    CORS_ALLOWED_METHODS         = var.cors_allowed_methods
+    CORS_ALLOWED_HEADERS         = var.cors_allowed_headers
+    CORS_ALLOW_CREDENTIALS       = tostring(var.cors_allow_credentials)
+    SECURITY_HSTS_ENABLED        = tostring(var.security_hsts_enabled)
+    SMTP_HOST                    = var.smtp_host
+    SMTP_PORT                    = tostring(var.smtp_port)
+    SMTP_FROM                    = var.smtp_from
+    SMTP_USE_TLS                 = tostring(var.smtp_use_tls)
+    SMTP_STARTTLS                = tostring(var.smtp_starttls)
+    SMTP_REQUIRE_TLS             = tostring(var.smtp_require_tls)
+    AUTO_CREATE_SCHEMA           = "false"
+    SKIP_CPF_EXTERNAL_VALIDATION = tostring(var.skip_cpf_external_validation)
+  }
+}
+
+resource "kubernetes_job_v1" "migration" {
+  metadata {
+    name      = local.migration_job_name
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.migration_labels
+  }
+
+  wait_for_completion = true
+
+  spec {
+    backoff_limit              = 1
+    active_deadline_seconds    = 300
+    ttl_seconds_after_finished = 600
+
+    template {
+      metadata {
+        labels = local.migration_labels
+      }
+
+      spec {
+        restart_policy                   = "OnFailure"
+        termination_grace_period_seconds = 30
+
+        security_context {
+          run_as_non_root = true
+          run_as_user     = 10001
+          run_as_group    = 10001
+          fs_group        = 10001
+
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        container {
+          name              = "alembic"
+          image             = var.image_reference
+          image_pull_policy = "IfNotPresent"
+          command           = ["sh", "-c"]
+          args = [
+            "set -eu; attempt=1; until python -c 'import os, psycopg2; connection=psycopg2.connect(os.environ[\"DATABASE_URL\"], connect_timeout=2); connection.close()'; do if [ \"$attempt\" -ge 5 ]; then echo \"migration preflight failed: database unavailable\"; exit 10; fi; echo \"migration preflight: database unavailable, retry $attempt/4\"; attempt=$((attempt + 1)); sleep 5; done; echo \"migration preflight complete\"; migration_status=0; python -m src.scripts.run_migrations || migration_status=$?; if [ \"$migration_status\" -eq 10 ]; then echo \"migration failed: database unavailable while acquiring lock\"; exit 10; fi; if [ \"$migration_status\" -ne 0 ]; then echo \"migration failed\"; exit 20; fi"
+          ]
+
+          env_from {
+            config_map_ref {
+              name = kubernetes_config_map_v1.app.metadata[0].name
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = var.secret_name
+            }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            read_only_root_filesystem  = true
+
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          volume_mount {
+            name       = "tmp"
+            mount_path = "/tmp"
+          }
+        }
+
+        volume {
+          name = "tmp"
+
+          empty_dir {}
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [
+    kubernetes_config_map_v1.app,
+    kubernetes_deployment_v1.postgres,
+  ]
+}
+
+resource "kubernetes_deployment_v1" "backend" {
+  metadata {
+    name      = local.backend_name
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.backend_labels
+  }
+
+  spec {
+    replicas                  = var.replicas
+    revision_history_limit    = 5
+    min_ready_seconds         = 5
+    progress_deadline_seconds = 600
+
+    selector {
+      match_labels = {
+        app = "auto-shop-backend"
+      }
+    }
+
+    strategy {
+      type = "RollingUpdate"
+
+      rolling_update {
+        max_unavailable = "0"
+        max_surge       = "1"
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.backend_labels
+      }
+
+      spec {
+        restart_policy                   = "Always"
+        termination_grace_period_seconds = 30
+
+        security_context {
+          run_as_non_root = true
+          run_as_user     = 10001
+          run_as_group    = 10001
+          fs_group        = 10001
+
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        container {
+          name              = "backend-api"
+          image             = var.image_reference
+          image_pull_policy = "IfNotPresent"
+          command           = ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+          port {
+            name           = "http"
+            container_port = 8000
+            protocol       = "TCP"
+          }
+
+          env_from {
+            config_map_ref {
+              name = kubernetes_config_map_v1.app.metadata[0].name
+            }
+          }
+
+          env_from {
+            secret_ref {
+              name = var.secret_name
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = "250m"
+              memory = "256Mi"
+            }
+
+            limits = {
+              cpu    = "500m"
+              memory = "512Mi"
+            }
+          }
+
+          startup_probe {
+            http_get {
+              path = "/health/live"
+              port = "http"
+            }
+
+            period_seconds    = 5
+            timeout_seconds   = 3
+            failure_threshold = 30
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/health/live"
+              port = "http"
+            }
+
+            period_seconds    = 15
+            timeout_seconds   = 3
+            failure_threshold = 3
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/health/ready"
+              port = "http"
+            }
+
+            period_seconds    = 5
+            timeout_seconds   = 3
+            success_threshold = 1
+            failure_threshold = 3
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            read_only_root_filesystem  = true
+
+            capabilities {
+              drop = ["ALL"]
+            }
+          }
+
+          volume_mount {
+            name       = "tmp"
+            mount_path = "/tmp"
+          }
+        }
+
+        volume {
+          name = "tmp"
+
+          empty_dir {}
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.migration]
+}
+
+resource "kubernetes_service_v1" "backend" {
+  metadata {
+    name      = local.backend_service
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.backend_labels
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      app = "auto-shop-backend"
+    }
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = "http"
+    }
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler_v2" "backend" {
+  metadata {
+    name      = "auto-shop-backend-hpa"
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = local.backend_labels
+  }
+
+  spec {
+    min_replicas = 2
+    max_replicas = 10
+
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind        = "Deployment"
+      name        = kubernetes_deployment_v1.backend.metadata[0].name
+    }
+
+    metric {
+      type = "Resource"
+
+      resource {
+        name = "cpu"
+
+        target {
+          type                = "Utilization"
+          average_utilization = 70
+        }
+      }
+    }
+
+    metric {
+      type = "Resource"
+
+      resource {
+        name = "memory"
+
+        target {
+          type                = "Utilization"
+          average_utilization = 80
+        }
+      }
+    }
+
+    behavior {
+      scale_up {
+        stabilization_window_seconds = 0
+        select_policy                = "Max"
+
+        policy {
+          type           = "Percent"
+          value          = 100
+          period_seconds = 15
+        }
+
+        policy {
+          type           = "Pods"
+          value          = 2
+          period_seconds = 15
+        }
+      }
+
+      scale_down {
+        stabilization_window_seconds = 300
+        select_policy                = "Min"
+
+        policy {
+          type           = "Percent"
+          value          = 10
+          period_seconds = 60
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "backend" {
+  count = var.enable_ingress ? 1 : 0
+
+  metadata {
+    name      = "auto-shop-ingress"
+    namespace = kubernetes_namespace_v1.auto_shop.metadata[0].name
+    labels    = merge(local.common_labels, { "app.kubernetes.io/component" = "ingress" })
+    annotations = var.environment == "local" ? {
+      "nginx.ingress.kubernetes.io/ssl-redirect" = "false"
+      } : {
+      "nginx.ingress.kubernetes.io/ssl-redirect"       = "true"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" = "true"
+    }
+  }
+
+  spec {
+    ingress_class_name = var.ingress_class_name
+
+    dynamic "tls" {
+      for_each = var.environment == "local" ? [] : [true]
+
+      content {
+        hosts       = [var.ingress_host]
+        secret_name = var.ingress_tls_secret_name
+      }
+    }
+
+    rule {
+      host = var.ingress_host
+
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+
+          backend {
+            service {
+              name = kubernetes_service_v1.backend.metadata[0].name
+
+              port {
+                number = 80
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/k8s.tf
+++ b/infra/k8s.tf
@@ -42,9 +42,8 @@ resource "kubernetes_job_v1" "migration" {
   wait_for_completion = true
 
   spec {
-    backoff_limit              = 1
-    active_deadline_seconds    = 300
-    ttl_seconds_after_finished = 600
+    backoff_limit           = 1
+    active_deadline_seconds = 300
 
     template {
       metadata {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path    = var.kubeconfig_path
+  config_context = var.kube_context
+}
+
+locals {
+  common_labels = {
+    "app.kubernetes.io/name"        = "auto-shop-system"
+    "app.kubernetes.io/part-of"     = "auto-shop-platform"
+    "app.kubernetes.io/environment" = var.environment
+  }
+
+  backend_labels = merge(local.common_labels, {
+    "app.kubernetes.io/component" = "backend"
+    app                           = "auto-shop-backend"
+  })
+
+  migration_labels = merge(local.common_labels, {
+    "app.kubernetes.io/component" = "migrate"
+    app                           = "auto-shop-migrate"
+  })
+
+  database_labels = merge(local.common_labels, {
+    "app.kubernetes.io/component" = "database"
+    app                           = "postgres"
+  })
+
+  backend_name       = "auto-shop-backend"
+  backend_service    = "auto-shop-backend-service"
+  config_map_name    = "auto-shop-config"
+  migration_job_name = "auto-shop-migrate-${substr(sha256(var.image_reference), 0, 12)}"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,29 @@
+output "namespace" {
+  description = "Namespace Kubernetes gerenciado."
+  value       = kubernetes_namespace_v1.auto_shop.metadata[0].name
+}
+
+output "backend_deployment" {
+  description = "Nome do Deployment do backend."
+  value       = kubernetes_deployment_v1.backend.metadata[0].name
+}
+
+output "backend_service" {
+  description = "Nome do Service do backend."
+  value       = kubernetes_service_v1.backend.metadata[0].name
+}
+
+output "backend_hpa" {
+  description = "Nome do HPA do backend."
+  value       = kubernetes_horizontal_pod_autoscaler_v2.backend.metadata[0].name
+}
+
+output "migration_job" {
+  description = "Nome do Job de migration associado à imagem implantada."
+  value       = kubernetes_job_v1.migration.metadata[0].name
+}
+
+output "postgres_service" {
+  description = "Nome do Service PostgreSQL quando o banco local está habilitado."
+  value       = var.enable_local_database ? kubernetes_service_v1.postgres[0].metadata[0].name : null
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,18 @@
+environment            = "local"
+namespace              = "auto-shop"
+kube_context           = "kind-kind"
+image_reference        = "auto-shop-system:local"
+enable_local_database  = true
+enable_ingress         = true
+ingress_host           = null
+app_env                = "development"
+app_base_url           = "http://localhost:8000"
+frontend_public_url    = "http://localhost:4200"
+cors_allowed_origins   = "http://localhost:4200"
+smtp_host              = "mailhog"
+smtp_port              = 1025
+security_hsts_enabled  = false
+skip_cpf_external_validation = true
+
+# O Secret deve ser criado previamente fora do Terraform.
+# kube_context = "kind-kind"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,261 @@
+variable "environment" {
+  description = "Ambiente Kubernetes gerenciado pelo Terraform."
+  type        = string
+  default     = "local"
+
+  validation {
+    condition     = contains(["local", "staging", "production"], var.environment)
+    error_message = "environment deve ser local, staging ou production."
+  }
+}
+
+variable "namespace" {
+  description = "Namespace Kubernetes da aplicação."
+  type        = string
+  default     = "auto-shop"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", var.namespace)) && length(var.namespace) <= 63
+    error_message = "namespace deve ser um nome DNS-1123 válido com no máximo 63 caracteres."
+  }
+}
+
+variable "kubeconfig_path" {
+  description = "Caminho opcional para o kubeconfig; nulo usa a configuração padrão do provider."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "kube_context" {
+  description = "Contexto Kubernetes usado pelo provider."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "image_reference" {
+  description = "Imagem da API com tag SHA hexadecimal ou digest; no ambiente local também aceita a tag local."
+  type        = string
+  default     = "auto-shop-system:local"
+
+  validation {
+    condition = (
+      can(regex("^.+@sha256:[0-9a-f]{64}$", var.image_reference)) ||
+      can(regex("^.+:[0-9a-f]{7,64}$", var.image_reference)) ||
+      (var.environment == "local" && can(regex("^.+:local([-.a-zA-Z0-9_]+)?$", var.image_reference)))
+    ) && !can(regex("registry\\.example\\.com", var.image_reference))
+    error_message = "image_reference deve usar uma tag SHA, digest sha256 ou, somente em local, uma tag local."
+  }
+}
+
+variable "secret_name" {
+  description = "Secret existente que contém DATABASE_URL e as demais credenciais da aplicação."
+  type        = string
+  default     = "auto-shop-secrets"
+}
+
+variable "app_env" {
+  description = "Valor APP_ENV usado no ConfigMap."
+  type        = string
+  default     = "development"
+
+  validation {
+    condition = (
+      (var.environment == "local" && contains(["development", "dev", "local"], var.app_env)) ||
+      (var.environment != "local" && var.app_env == var.environment)
+    )
+    error_message = "app_env deve ser development/dev/local no ambiente local e igual ao ambiente em staging/production."
+  }
+}
+
+variable "app_base_url" {
+  description = "URL pública base da API."
+  type        = string
+  default     = "http://localhost:8000"
+
+  validation {
+    condition     = var.environment == "local" || can(regex("^https://", var.app_base_url))
+    error_message = "app_base_url deve usar HTTPS fora do ambiente local."
+  }
+}
+
+variable "frontend_public_url" {
+  description = "URL pública do frontend."
+  type        = string
+  default     = "http://localhost:4200"
+
+  validation {
+    condition     = var.environment == "local" || can(regex("^https://", var.frontend_public_url))
+    error_message = "frontend_public_url deve usar HTTPS fora do ambiente local."
+  }
+}
+
+variable "cors_allowed_origins" {
+  description = "Origens permitidas pelo CORS, separadas por vírgula."
+  type        = string
+  default     = "http://localhost:4200"
+
+  validation {
+    condition     = var.environment == "local" || !can(regex("http://|localhost|127\\.0\\.0\\.1", var.cors_allowed_origins))
+    error_message = "cors_allowed_origins não pode apontar para HTTP ou localhost fora do ambiente local."
+  }
+}
+
+variable "cors_allowed_methods" {
+  description = "Métodos permitidos pelo CORS."
+  type        = string
+  default     = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+}
+
+variable "cors_allowed_headers" {
+  description = "Headers permitidos pelo CORS."
+  type        = string
+  default     = "Authorization,Content-Type,X-CSRF-Token,X-Request-ID,Accept"
+}
+
+variable "cors_allow_credentials" {
+  description = "Permite credenciais nas requisições CORS."
+  type        = bool
+  default     = true
+}
+
+variable "security_hsts_enabled" {
+  description = "Ativa HSTS na aplicação."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.environment == "local" || var.security_hsts_enabled
+    error_message = "security_hsts_enabled deve ser true fora do ambiente local."
+  }
+}
+
+variable "smtp_host" {
+  description = "Host SMTP não sensível; credenciais continuam no Secret."
+  type        = string
+  default     = "mailhog"
+
+  validation {
+    condition     = var.environment == "local" || lower(var.smtp_host) != "mailhog"
+    error_message = "smtp_host não pode ser mailhog fora do ambiente local."
+  }
+}
+
+variable "smtp_port" {
+  description = "Porta SMTP."
+  type        = number
+  default     = 1025
+}
+
+variable "smtp_from" {
+  description = "Remetente padrão de e-mail."
+  type        = string
+  default     = "noreply@oficina.local"
+}
+
+variable "smtp_use_tls" {
+  description = "Ativa TLS SMTP."
+  type        = bool
+  default     = false
+}
+
+variable "smtp_starttls" {
+  description = "Ativa STARTTLS SMTP."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.environment == "local" || var.smtp_starttls
+    error_message = "smtp_starttls deve ser true fora do ambiente local."
+  }
+}
+
+variable "smtp_require_tls" {
+  description = "Exige TLS SMTP."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.environment == "local" || var.smtp_require_tls
+    error_message = "smtp_require_tls deve ser true fora do ambiente local."
+  }
+}
+
+variable "skip_cpf_external_validation" {
+  description = "Ignora a validação externa de CPF no ambiente local."
+  type        = bool
+  default     = true
+
+  validation {
+    condition     = var.environment == "local" || !var.skip_cpf_external_validation
+    error_message = "A validação externa de CPF não pode ser ignorada fora do ambiente local."
+  }
+}
+
+variable "replicas" {
+  description = "Réplicas iniciais do Deployment; deve ser compatível com o mínimo do HPA."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.replicas >= 2 && var.replicas <= 10
+    error_message = "replicas deve estar entre 2 e 10 para manter a disponibilidade mínima."
+  }
+}
+
+variable "enable_local_database" {
+  description = "Cria PostgreSQL, PVC e Service somente para o ambiente local."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.enable_local_database || var.environment == "local"
+    error_message = "enable_local_database=true só é permitido quando environment=local."
+  }
+}
+
+variable "postgres_image" {
+  description = "Imagem do PostgreSQL usado exclusivamente no ambiente local."
+  type        = string
+  default     = "postgres:16-alpine"
+}
+
+variable "postgres_storage" {
+  description = "Storage solicitado para o PostgreSQL local."
+  type        = string
+  default     = "5Gi"
+}
+
+variable "enable_ingress" {
+  description = "Cria o Ingress da API."
+  type        = bool
+  default     = true
+}
+
+variable "ingress_class_name" {
+  description = "IngressClass usado pelo Ingress."
+  type        = string
+  default     = "nginx"
+}
+
+variable "ingress_host" {
+  description = "Host do Ingress; nulo gera uma regra sem host para uso local."
+  type        = string
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = (
+      (var.environment == "local" && (var.ingress_host == null || can(regex("^[a-z0-9.-]+$", var.ingress_host)))) ||
+      (var.environment != "local" && var.ingress_host != null && can(regex("^[a-z0-9.-]+$", var.ingress_host)))
+    )
+    error_message = "ingress_host é opcional apenas em local e deve ser um hostname válido nos demais ambientes."
+  }
+}
+
+variable "ingress_tls_secret_name" {
+  description = "Secret TLS usado em ambientes com HTTPS."
+  type        = string
+  default     = "auto-shop-tls"
+}


### PR DESCRIPTION
### 📝 Descrição

Implementa a alternativa declarativa de infraestrutura Kubernetes com Terraform para a Issue #42.

A implementação utiliza o provider oficial `hashicorp/kubernetes` em um cluster já existente e gerencia a stack da aplicação no diretório `infra/`:

- Namespace, ConfigMap, Deployment, Service ClusterIP, HPA, Ingress e Job de migration.
- Job de migration versionado pela imagem imutável da API e aguardado antes da criação do Deployment.
- PostgreSQL local opcional, incluindo PVC, Deployment e Service, habilitado apenas com `enable_local_database=true` no ambiente `local`.
- Banco externo para staging/production, sem provisionamento de AWS, EKS, RDS, VPC ou IAM.
- Secrets existentes referenciados pelo Terraform, sem credenciais armazenadas em arquivos versionados, outputs ou código.
- Validações de CI para formatação, inicialização, validação e planos dos ambientes local, staging e production.
- Documentação atualizada com configuração do provider, criação prévia dos Secrets, uso local, imports e regra de ownership entre Terraform e Kustomize.

Também foi corrigido o fluxo do PVC local para funcionar com StorageClasses `WaitForFirstConsumer`, permitindo que o Deployment do PostgreSQL seja criado e realize o primeiro consumo do volume.

### 🎫 Relacionado à Issue ou Ticket
[#42 — Terraform em infra](https://github.com/Software-Architecture-Group-7-FIAP/auto-shop-system/issues/42)

### 🛠️ Tipo de Alteração
- [x] ✨ Nova Funcionalidade
- [ ] 🐛 Correção de Bug
- [ ] ♻️ Refatoração de Código
- [x] 📖 Documentação
- [x] 🚀 Melhorias
- [x] 🧪 Testes

### 🧐 Como Testar?
1. Faça checkout desta branch.
2. Configure um cluster Kubernetes acessível pelo kubeconfig e crie previamente o Secret `auto-shop-secrets`.
3. Execute `terraform -chdir=infra init`.
4. Execute `terraform -chdir=infra fmt -check -recursive` e `terraform -chdir=infra validate`.
5. Para o ambiente local, execute o plan/apply com `enable_local_database=true` e verifique Namespace, PostgreSQL, PVC Bound, migration concluída, backend, Service, HPA e Ingress.
6. Para staging/production, execute o plan com `enable_local_database=false` e confirme que nenhum recurso local de PostgreSQL será criado.
7. Execute `terraform -chdir=infra plan` após o apply e confirme que não existem alterações pendentes.
8. Não aplique Terraform e Kustomize simultaneamente no mesmo namespace.

### 🖼️ Capturas de Tela / Gravações (Se aplicável)
Não aplicável.

### 📋 Checklist de Verificação
- [x] Meu código segue o padrão de estilo deste projeto.
- [x] Adicionei validações que cobrem os cenários local, staging e production.
- [ ] Todas as verificações (CI/CD) passaram com sucesso.
- [x] Atualizei a documentação (se necessário).